### PR TITLE
🧪 Add system/integration tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,6 +61,10 @@ group :development, :test do
   gem "factory_bot_rails"
   gem "faker"
   gem "shoulda-matchers"
+
+  # System tests
+  gem "capybara"
+  gem "cuprite"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,6 +75,8 @@ GEM
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
       uri (>= 0.13.1)
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
     ast (2.4.3)
     base64 (0.3.0)
     bcrypt (3.1.20)
@@ -88,9 +90,21 @@ GEM
     brakeman (8.0.5)
       racc
     builder (3.3.0)
+    capybara (3.40.0)
+      addressable
+      matrix
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.11)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (>= 1.5, < 3.0)
+      xpath (~> 3.2)
     concurrent-ruby (1.3.6)
     connection_pool (3.0.2)
     crass (1.0.6)
+    cuprite (0.17)
+      capybara (~> 3.0)
+      ferrum (~> 0.17.0)
     date (3.5.1)
     debug (1.11.1)
       irb (~> 1.10)
@@ -110,6 +124,12 @@ GEM
       railties (>= 6.1.0)
     faker (3.8.0)
       i18n (>= 1.8.11, < 2)
+    ferrum (0.17.2)
+      addressable (~> 2.5)
+      base64 (~> 0.2)
+      concurrent-ruby (~> 1.1)
+      webrick (~> 1.7)
+      websocket-driver (~> 0.7)
     ffi (1.17.2-aarch64-linux-gnu)
     ffi (1.17.2-aarch64-linux-musl)
     ffi (1.17.2-arm-linux-gnu)
@@ -165,6 +185,7 @@ GEM
       net-pop
       net-smtp
     marcel (1.1.0)
+    matrix (0.4.3)
     mini_magick (5.3.1)
       logger
     mini_mime (1.1.5)
@@ -224,6 +245,7 @@ GEM
     psych (5.3.1)
       date
       stringio
+    public_suffix (7.0.5)
     puma (7.1.0)
       nio4r (~> 2.0)
     raabro (1.4.0)
@@ -384,10 +406,13 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    webrick (1.9.2)
     websocket-driver (0.8.0)
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    xpath (3.2.0)
+      nokogiri (~> 1.8)
     zeitwerk (2.7.4)
 
 PLATFORMS
@@ -407,6 +432,8 @@ DEPENDENCIES
   bcrypt (~> 3.1.7)
   bootsnap
   brakeman
+  capybara
+  cuprite
   debug
   factory_bot_rails
   faker

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "capybara/rspec"
+require "capybara/cuprite"
+
+Capybara.register_driver(:cuprite) do |app|
+  Capybara::Cuprite::Driver.new(
+    app,
+    window_size: [ 1200, 800 ],
+    headless: true,
+    process_timeout: 30,
+    timeout: 30,
+    browser_options: {
+      "no-sandbox" => nil,
+      "disable-gpu" => nil,
+      "disable-dev-shm-usage" => nil
+    }
+  )
+end
+
+# Speed up tests
+Capybara.default_max_wait_time = 5
+Capybara.server = :puma, { Silent: true }
+
+RSpec.configure do |config|
+  config.before(:each, type: :system) do
+    driven_by :cuprite
+  end
+end

--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module SystemHelpers
+  def sign_in_as(user)
+    visit sign_in_path
+    fill_in "Email", with: user.email
+    fill_in "Password", with: "password123"
+    click_button "Sign in"
+  end
+
+  def sign_out
+    click_link "Sign Out"
+  end
+end
+
+RSpec.configure do |config|
+  config.include SystemHelpers, type: :system
+end

--- a/spec/system/authentication_spec.rb
+++ b/spec/system/authentication_spec.rb
@@ -1,0 +1,57 @@
+require "rails_helper"
+
+RSpec.describe "Authentication", type: :system do
+  let(:user) { create(:user, email: "test@example.com") }
+
+  describe "signing in" do
+    it "allows a user to sign in with valid credentials" do
+      visit sign_in_path
+
+      fill_in "Email", with: user.email
+      fill_in "Password", with: "password123"
+      click_button "Sign in"
+
+      expect(page).to have_current_path(root_path)
+      expect(page).to have_content(user.email)
+    end
+
+    it "does not redirect with invalid credentials" do
+      visit sign_in_path
+
+      fill_in "Email", with: user.email
+      fill_in "Password", with: "wrongpassword"
+      click_button "Sign in"
+
+      # User stays on sign in form, not redirected to home
+      expect(page).not_to have_current_path(root_path)
+      expect(page).to have_button("Sign in")
+    end
+  end
+
+  describe "signing out" do
+    before { sign_in_as(user) }
+
+    it "allows a user to sign out" do
+      click_link "Sign Out"
+
+      expect(page).to have_current_path(root_path)
+      expect(page).to have_link("Sign In")
+    end
+  end
+
+  describe "protected routes" do
+    it "redirects to sign in when accessing protected pages" do
+      visit new_recipe_path
+
+      expect(page).to have_current_path(sign_in_path)
+    end
+
+    it "allows access to protected pages after signing in" do
+      sign_in_as(user)
+      visit new_recipe_path
+
+      expect(page).to have_current_path(new_recipe_path)
+      expect(page).to have_content("New recipe")
+    end
+  end
+end

--- a/spec/system/baskets_spec.rb
+++ b/spec/system/baskets_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+RSpec.describe "Baskets", type: :system do
+  let(:user) { create(:user) }
+  let!(:recipe) { create(:recipe, title: "Pancakes for Breakfast") }
+
+  describe "basket functionality" do
+    before { sign_in_as(user) }
+
+    it "shows the basket count in the header" do
+      visit recipes_path
+
+      # User starts with 0 meals
+      expect(page).to have_content("0 Meals")
+    end
+
+    it "updates basket count when adding a recipe" do
+      # Create a basket entry directly
+      create(:basket, user: user, recipe: recipe)
+
+      visit recipes_path
+
+      expect(page).to have_content("1 Meal")
+    end
+
+    it "shows multiple meals when basket has multiple recipes" do
+      recipes = create_list(:recipe, 3)
+      recipes.each { |r| create(:basket, user: user, recipe: r) }
+
+      visit recipes_path
+
+      expect(page).to have_content("3 Meals")
+    end
+  end
+
+  describe "unauthenticated users" do
+    it "does not show basket count" do
+      visit recipes_path
+
+      expect(page).not_to have_content("Meals")
+    end
+  end
+end

--- a/spec/system/categories_spec.rb
+++ b/spec/system/categories_spec.rb
@@ -1,0 +1,65 @@
+require "rails_helper"
+
+RSpec.describe "Categories", type: :system do
+  let(:user) { create(:user) }
+
+  describe "browsing categories" do
+    it "shows all categories on the index page" do
+      categories = create_list(:category, 3)
+
+      visit categories_path
+
+      categories.each do |category|
+        expect(page).to have_content(category.name)
+      end
+    end
+
+    it "can view a category detail page" do
+      category = create(:category, name: "Breakfast Foods")
+
+      visit category_path(category)
+
+      expect(page).to have_content("Breakfast Foods")
+    end
+  end
+
+  describe "category management" do
+    before { sign_in_as(user) }
+
+    it "can access the new category page when authenticated" do
+      visit new_category_path
+
+      expect(page).to have_field("Name")
+    end
+
+    it "can create a new category" do
+      visit new_category_path
+
+      fill_in "Name", with: "Desserts"
+      click_button "Create Category"
+
+      expect(page).to have_content("Category was successfully created")
+      expect(page).to have_content("Desserts")
+    end
+
+    context "with an existing category" do
+      let!(:category) { create(:category, name: "Old Category") }
+
+      it "can view the edit page" do
+        visit edit_category_path(category)
+
+        expect(page).to have_field("Name", with: "Old Category")
+      end
+
+      it "can update the category" do
+        visit edit_category_path(category)
+
+        fill_in "Name", with: "New Name"
+        click_button "Update Category"
+
+        expect(page).to have_content("Category was successfully updated")
+        expect(page).to have_content("New Name")
+      end
+    end
+  end
+end

--- a/spec/system/home_page_spec.rb
+++ b/spec/system/home_page_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+RSpec.describe "Home Page", type: :system do
+  describe "random recipe display" do
+    it "shows a random recipe when recipes exist" do
+      recipes = create_list(:recipe, 3)
+
+      visit root_path
+
+      # Should show at least one of the recipe titles
+      recipe_titles = recipes.map(&:title)
+      displayed = recipe_titles.any? { |title| page.has_content?(title) }
+      expect(displayed).to be true
+    end
+
+    it "handles the case when no recipes exist" do
+      visit root_path
+
+      expect(page).to have_http_status(:ok)
+    end
+  end
+
+  describe "navigation" do
+    it "allows navigating to recipes page" do
+      visit root_path
+
+      click_link "Recipes"
+
+      expect(page).to have_current_path(recipes_path)
+    end
+
+    it "allows navigating to categories page" do
+      visit root_path
+
+      click_link "Categories"
+
+      expect(page).to have_current_path(categories_path)
+    end
+  end
+end

--- a/spec/system/recipes_spec.rb
+++ b/spec/system/recipes_spec.rb
@@ -1,0 +1,65 @@
+require "rails_helper"
+
+RSpec.describe "Recipes", type: :system do
+  let(:user) { create(:user) }
+  let(:category) { create(:category, name: "Breakfast") }
+
+  describe "browsing recipes" do
+    it "shows all recipes on the index page" do
+      recipes = create_list(:recipe, 3)
+
+      visit recipes_path
+
+      recipes.each do |recipe|
+        expect(page).to have_content(recipe.title)
+      end
+    end
+
+    it "can view a recipe details page" do
+      recipe = create(:recipe, title: "Delicious Pancakes")
+
+      visit recipe_path(recipe)
+
+      expect(page).to have_content("Delicious Pancakes")
+    end
+  end
+
+  describe "searching recipes" do
+    let!(:pancakes) { create(:recipe, title: "Fluffy Pancakes") }
+    let!(:omelette) { create(:recipe, title: "Cheese Omelette") }
+
+    it "finds recipes by title using the search form" do
+      visit recipes_path
+
+      fill_in "query", with: "pancakes"
+      find("input[name='query']").send_keys(:enter)
+
+      expect(page).to have_content("Fluffy Pancakes")
+      expect(page).not_to have_content("Cheese Omelette")
+    end
+  end
+
+  describe "recipe management" do
+    before do
+      category
+      sign_in_as(user)
+    end
+
+    it "can access the new recipe page when authenticated" do
+      visit new_recipe_path
+
+      expect(page).to have_content("New recipe")
+      expect(page).to have_field("Title")
+    end
+
+    context "with an existing recipe" do
+      let!(:recipe) { create(:recipe, title: "Old Title") }
+
+      it "can view the edit page" do
+        visit edit_recipe_path(recipe)
+
+        expect(page).to have_field("Title", with: "Old Title")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #62

## Summary
- Added Capybara and Cuprite for headless browser testing
- Created system tests covering full user flows
- Configured test helpers for authentication

## Changes
- **Gemfile**: Added capybara and cuprite gems
- **spec/support/capybara.rb**: Cuprite driver configuration
- **spec/support/system_helpers.rb**: Sign in/out helpers for system tests
- **spec/system/**: 5 test files covering all major features

## Test Coverage
24 system tests covering:
- **Authentication** (5 tests): sign in, sign out, protected routes
- **Recipes** (5 tests): browsing, searching, management pages
- **Categories** (6 tests): browsing and CRUD operations  
- **Baskets** (4 tests): basket count display
- **Home page** (4 tests): random recipe, navigation

## Full Test Suite
```
175 examples, 0 failures
- 71 model tests
- 80 request tests
- 24 system tests
```

## Note
System tests require Chrome/Chromium to be installed for the Cuprite driver.

---
🤖 Generated with [Claude Code](https://claude.ai/code)