### PR TITLE
Add image upload support to recipes API

### DIFF
--- a/app/controllers/api/v1/recipes_controller.rb
+++ b/app/controllers/api/v1/recipes_controller.rb
@@ -28,12 +28,14 @@ module Api
 
       def create
         @recipe = Recipe.new(recipe_params)
+        attach_image if params[:recipe][:image_data].present?
         @recipe.save!
         render :show, status: :created
       end
 
       def update
         @recipe.update!(recipe_params)
+        attach_image if params[:recipe][:image_data].present?
         render :show
       end
 
@@ -58,6 +60,33 @@ module Api
             p[:instructions] = params.dig(:recipe, :instructions)
           end
         end
+      end
+
+      def attach_image
+        image_data = params[:recipe][:image_data]
+        return unless image_data.present?
+
+        # Parse data URL: data:image/jpeg;base64,/9j/4AAQ...
+        if image_data.start_with?("data:")
+          matches = image_data.match(%r{data:image/(\w+);base64,(.+)})
+          return unless matches
+
+          extension = matches[1]
+          base64_data = matches[2]
+        else
+          # Assume raw base64, default to jpeg
+          extension = "jpeg"
+          base64_data = image_data
+        end
+
+        decoded = Base64.decode64(base64_data)
+        filename = "recipe_#{Time.current.to_i}.#{extension}"
+
+        @recipe.image.attach(
+          io: StringIO.new(decoded),
+          filename: filename,
+          content_type: "image/#{extension}"
+        )
       end
     end
   end

--- a/spec/requests/api/v1/recipes_image_upload_spec.rb
+++ b/spec/requests/api/v1/recipes_image_upload_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Api::V1::Recipes Image Upload", type: :request do
+  let(:user) { create(:user, :with_api_token) }
+  let(:headers) { { "Authorization" => "Bearer #{user.api_token}", "Content-Type" => "application/json", "Accept" => "application/json" } }
+  let(:category) { create(:category) }
+
+  # Small 1x1 red pixel JPEG in base64
+  let(:base64_image) do
+    "/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRof" \
+    "Hh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwh" \
+    "MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAAR" \
+    "CAABAAEDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAn/xAAUEAEAAAAAAAAAAAAAAAAA" \
+    "AAAA/8QAFQEBAQAAAAAAAAAAAAAAAAAAAAX/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oADAMB" \
+    "AAIRAxEAPwCwAB//2Q=="
+  end
+
+  describe "POST /api/v1/recipes with image_data" do
+    let(:recipe_params) do
+      {
+        recipe: {
+          title: "Recipe with Image",
+          description: "A recipe with an uploaded image",
+          serves: 4,
+          prep_time: "30 minutes",
+          category_id: category.id,
+          instructions: "Cook it well",
+          ingredients: [ { name: "flour", quantity: "2", unit: "cups" } ],
+          nutrition: {
+            calories: "300", protein: "10g", fat: "5g",
+            carbs: "40g", fibre: "3g", sugar: "5g", sodium: "200mg"
+          },
+          image_data: "data:image/jpeg;base64,#{base64_image}"
+        }
+      }
+    end
+
+    it "creates a recipe with an attached image" do
+      post "/api/v1/recipes", params: recipe_params.to_json, headers: headers
+
+      expect(response).to have_http_status(:created)
+      recipe = Recipe.last
+      expect(recipe.title).to eq("Recipe with Image")
+      expect(recipe.image).to be_attached
+    end
+
+    it "handles raw base64 without data URL prefix" do
+      recipe_params[:recipe][:image_data] = base64_image
+
+      post "/api/v1/recipes", params: recipe_params.to_json, headers: headers
+
+      expect(response).to have_http_status(:created)
+      recipe = Recipe.last
+      expect(recipe.image).to be_attached
+    end
+  end
+
+  describe "PUT /api/v1/recipes/:id with image_data" do
+    let!(:recipe) { create(:recipe) }
+
+    it "attaches an image to an existing recipe" do
+      params = {
+        recipe: {
+          image_data: "data:image/jpeg;base64,#{base64_image}"
+        }
+      }
+
+      put "/api/v1/recipes/#{recipe.id}", params: params.to_json, headers: headers
+
+      expect(response).to have_http_status(:ok)
+      recipe.reload
+      expect(recipe.image).to be_attached
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Accept base64-encoded images in recipe create/update requests
- Support both data URL format and raw base64
- Attach images via Active Storage

## API Changes

### Create Recipe with Image

```json
POST /api/v1/recipes
{
  "recipe": {
    "title": "...",
    "image_data": "data:image/jpeg;base64,/9j/4AAQ..."
  }
}
```

### Update Recipe with Image

```json
PUT /api/v1/recipes/:id
{
  "recipe": {
    "image_data": "data:image/jpeg;base64,..."
  }
}
```

## Test plan

- [x] Unit tests pass (3 new tests)
- [x] All API tests pass (25 total)
- [ ] Manual test: create recipe with image via curl/Swagger

Closes #112
Part of #110

🤖 Generated with [Claude Code](https://claude.ai/claude-code)