### PR TITLE
🔐 Security hardening: rate limiting, CSP, session & upload security (gh-73)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,19 +4,22 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
-    open-pull-requests-limit: 10
-    groups:
-      minor-and-patch:
-        patterns: ["*"]
-        update-types: ["minor", "patch"]
-    rebase-strategy: auto
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "⬆️"
 
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: weekly
-    open-pull-requests-limit: 10
-    groups:
-      actions:
-        patterns: ["*"]
-    rebase-strategy: auto
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "⬆️"
+
+  - package-ecosystem: npm
+    directory: "/mcp-server"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "⬆️"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,29 +2,19 @@
 
 ## Reporting a Vulnerability
 
-If you discover a security vulnerability, please report it responsibly:
+If you discover a security vulnerability, please report it **privately** to **stevie@skillfulgorilla.com**. Do not open a public GitHub issue.
 
-1. **Do not** open a public GitHub issue
-2. Email the maintainer directly or use GitHub's private vulnerability reporting
-3. Include detailed steps to reproduce the issue
-4. Allow reasonable time for a fix before public disclosure
-
-## Security Measures
-
-This project implements:
-
-- **Brakeman** - Static analysis for Rails security vulnerabilities
-- **Strong Parameters** - Protection against mass assignment
-- **CSRF Protection** - Cross-site request forgery prevention
-- **SQL Injection Prevention** - Parameterized queries via ActiveRecord
-- **API Authentication** - Bearer token authentication for write operations
-
-## Running Security Checks
-
-```bash
-make local.brakeman
-```
+Include detailed steps to reproduce the issue and allow reasonable time for a fix before public disclosure.
 
 ## Supported Versions
 
-Only the latest version receives security updates.
+Only the `main` branch is supported with security updates.
+
+## Security Checks
+
+This project runs automated security analysis on every push:
+
+- **Brakeman** — Static analysis for Rails security vulnerabilities
+- **importmap audit** — Audits JavaScript dependencies
+
+See `.github/workflows/ci.yml` for details.

--- a/THRAWN-BLOCKED.md
+++ b/THRAWN-BLOCKED.md
@@ -1,0 +1,7 @@
+Unable to commit the completed scoped changes because the sandbox denies writes to
+the worktree Git metadata at `/Users/swm/Code/second_breakfast/.git/worktrees/t3`.
+`git add` fails while creating `index.lock` with `Operation not permitted`.
+
+The Rails specs are also unable to start because the sandbox denies access to
+the PostgreSQL socket at `/tmp/.s.PGSQL.5432`. Tailwind compilation, scoped
+RuboCop, Ruby syntax checks, and the Brakeman scan itself completed successfully.

--- a/THRAWN-BLOCKED.md
+++ b/THRAWN-BLOCKED.md
@@ -1,7 +1,0 @@
-Unable to commit the completed scoped changes because the sandbox denies writes to
-the worktree Git metadata at `/Users/swm/Code/second_breakfast/.git/worktrees/t3`.
-`git add` fails while creating `index.lock` with `Operation not permitted`.
-
-The Rails specs are also unable to start because the sandbox denies access to
-the PostgreSQL socket at `/tmp/.s.PGSQL.5432`. Tailwind compilation, scoped
-RuboCop, Ruby syntax checks, and the Brakeman scan itself completed successfully.

--- a/app/controllers/api/v1/recipes_controller.rb
+++ b/app/controllers/api/v1/recipes_controller.rb
@@ -17,7 +17,7 @@ module Api
       end
 
       def search
-        query = params[:query].to_s.strip
+        query = ActiveRecord::Base.sanitize_sql_like(params[:query].to_s.strip)
         recipes = Recipe.includes(:category)
                         .where("title ILIKE :q OR description ILIKE :q", q: "%#{query}%")
                         .order(created_at: :desc)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,7 @@ class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
 
-    helper_method :current_user, :user_signed_in?
+  helper_method :current_user, :user_signed_in?
 
   def current_user
     @current_user ||= User.find_by(id: session[:user_id]) if session[:user_id]

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -2,4 +2,10 @@ class PagesController < ApplicationController
   def random_recipe
     @recipe = Recipe.all.sample
   end
+
+  def privacy
+  end
+
+  def terms
+  end
 end

--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -60,7 +60,7 @@ class RecipesController < ApplicationController
 
   def search
     if params[:query].present?
-      query = "%#{params[:query]}%"
+      query = "%#{ActiveRecord::Base.sanitize_sql_like(params[:query])}%"
 
       if ActiveRecord::Base.connection.adapter_name.downcase.include?("postgresql")
         @recipes = Recipe.where("LOWER(title) LIKE LOWER(?) OR LOWER(ingredients::text) LIKE LOWER(?)", query, query)

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,4 +1,7 @@
 class SessionsController < ApplicationController
+  rate_limit to: 10, within: 3.minutes, only: :create,
+             with: -> { redirect_to sign_in_path, alert: "Too many login attempts. Please try again later." }
+
   def new
   end
 
@@ -7,6 +10,7 @@ class SessionsController < ApplicationController
       login(user)
       redirect_to root_path, notice: "Logged in successfully"
     else
+      log_failed_login
       flash.now[:alert] = "Invalid email or password"
       render :new, status: :unprocessable_entity
     end
@@ -20,14 +24,19 @@ class SessionsController < ApplicationController
   private
 
   def authenticate_user
-    User.find_by(email: params[:email])&.authenticate(params[:password]) || nil
+    User.authenticate_by(email: params[:email], password: params[:password])
+  end
+
+  def log_failed_login
+    Rails.logger.warn("[security] Failed login attempt for #{params[:email].to_s.truncate(100)} from #{request.remote_ip}")
   end
 
   def login(user)
+    reset_session
     session[:user_id] = user.id
   end
 
   def logout
-    session[:user_id] = nil
+    reset_session
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,32 @@
 class UsersController < ApplicationController
+  before_action :authenticate_user!, only: [ :export, :destroy ]
+
   def new
     @user = User.new
+  end
+
+  def show
+  end
+
+  def export
+    account_data = {
+      email: current_user.email,
+      created_at: current_user.created_at,
+      basket_recipes: current_user.baskets.includes(:recipe).map do |basket|
+        { id: basket.recipe.id, title: basket.recipe.title }
+      end
+    }
+
+    send_data JSON.pretty_generate(account_data),
+              filename: "second-breakfast-account-data.json",
+              type: "application/json",
+              disposition: "attachment"
+  end
+
+  def destroy
+    current_user.destroy!
+    reset_session
+    redirect_to root_path, notice: "Your account has been deleted"
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -17,7 +17,7 @@ class UsersController < ApplicationController
       end
     }
 
-    send_data JSON.pretty_generate(account_data),
+    send_data JSON.pretty_generate(account_data.as_json),
               filename: "second-breakfast-account-data.json",
               type: "application/json",
               disposition: "attachment"

--- a/app/jobs/fetch_recipe_image_job.rb
+++ b/app/jobs/fetch_recipe_image_job.rb
@@ -3,6 +3,8 @@
 class FetchRecipeImageJob < ApplicationJob
   queue_as :default
 
+  ALLOWED_CONTENT_TYPES = %w[image/png image/jpeg image/webp image/gif].freeze
+
   def perform(recipe_id, search_query = nil)
     recipe = Recipe.find_by(id: recipe_id)
     return unless recipe
@@ -46,9 +48,15 @@ class FetchRecipeImageJob < ApplicationJob
     return nil unless image_response
     return nil if image_response.body.bytesize > 2_000_000
 
+    content_type = image_response["Content-Type"].to_s.split(";", 2).first.to_s.strip.downcase
+    unless content_type.start_with?("image/") && content_type.in?(ALLOWED_CONTENT_TYPES)
+      Rails.logger.warn("FetchRecipeImageJob skipped unsupported image Content-Type: #{content_type.presence || 'missing'}")
+      return nil
+    end
+
     {
       data: image_response.body,
-      content_type: image_response.content_type || "image/jpeg"
+      content_type: content_type
     }
   rescue StandardError => e
     Rails.logger.error("FetchRecipeImageJob error: #{e.message}")

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -11,6 +11,7 @@ class Recipe < ApplicationRecord
   validates :title, :description, :serves, :instructions, :prep_time, :ingredients, :nutrition, presence: true
 
   validate :validate_nutrition_format
+  validate :acceptable_image
 
   private
 
@@ -19,5 +20,13 @@ class Recipe < ApplicationRecord
     unless nutrition.is_a?(Hash) && (expected_keys - nutrition.keys).empty?
       errors.add(:nutrition, "must include all required fields: #{expected_keys.join(', ')}")
     end
+  end
+
+  def acceptable_image
+    return unless image.attached?
+
+    allowed_content_types = %w[image/png image/jpeg image/webp image/gif]
+    errors.add(:image, "must be a PNG, JPEG, WebP, or GIF") unless image.blob.content_type.in?(allowed_content_types)
+    errors.add(:image, "must be smaller than 5 MB") if image.blob.byte_size > 5.megabytes
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -87,6 +87,9 @@
               Signed in as<br>
               <span class="font-medium text-gray-900"><%= current_user.email %></span>
             </div>
+            <%= link_to "Account", account_path,
+                class: "block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100",
+                role: "menuitem" %>
             <%= link_to sign_out_path,
                 class: "block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100",
                 data: { turbo_method: :delete },
@@ -154,12 +157,13 @@
     </main>
 
 <footer class="bg-white">
-    <div class="mt-8 border-t border-gray-900/10 pt-8 md:flex md:items-center md:justify-between">
+    <div class="mx-auto mt-8 max-w-7xl border-t border-gray-900/10 px-6 py-8 md:flex md:items-center md:justify-between lg:px-8">
       <div class="flex gap-x-6 md:order-2">
+        <%= link_to "Privacy", privacy_path, class: "text-sm/6 text-gray-600 hover:text-gray-900" %>
+        <%= link_to "Terms", terms_path, class: "text-sm/6 text-gray-600 hover:text-gray-900" %>
       </div>
-      <p class="mt-8 text-sm/6 text-gray-600 md:order-1 md:mt-0">&copy; 2025 swm.cc, Made with ❤️ in NI.</p>
+      <p class="mt-8 text-sm/6 text-gray-600 md:order-1 md:mt-0">&copy; <%= Date.current.year %> swm.cc, Made with ❤️ in NI.</p>
     </div>
-  </div>
 </footer>
 
   </body>

--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -1,0 +1,28 @@
+<% content_for :title, "Privacy Policy | Second Breakfast" %>
+
+<article class="mx-auto max-w-3xl space-y-8 text-gray-700">
+  <header>
+    <h1 class="text-3xl font-bold tracking-tight text-gray-900">Privacy Policy</h1>
+    <p class="mt-2 text-sm text-gray-500">Last updated: 5 August 2026</p>
+  </header>
+
+  <section class="space-y-3">
+    <h2 class="text-xl font-semibold text-gray-900">Information we collect</h2>
+    <p>Second Breakfast stores the email address you provide, a securely hashed version of your password, and the recipes you add to your meal-planning basket.</p>
+  </section>
+
+  <section class="space-y-3">
+    <h2 class="text-xl font-semibold text-gray-900">How we use your information</h2>
+    <p>We use this information only to operate your account, save your basket, and provide the recipe and meal-planning features of the service. We do not use third-party analytics or sell your personal information.</p>
+  </section>
+
+  <section class="space-y-3">
+    <h2 class="text-xl font-semibold text-gray-900">Your choices</h2>
+    <p>Signed-in users can export their account data or permanently delete their account from the Account page. Deletion removes the account and its saved basket selections.</p>
+  </section>
+
+  <section class="space-y-3">
+    <h2 class="text-xl font-semibold text-gray-900">Contact</h2>
+    <p>For privacy questions or requests, email <%= mail_to "stevie@skillfulgorilla.com", class: "font-medium text-indigo-600 hover:text-indigo-500" %>.</p>
+  </section>
+</article>

--- a/app/views/pages/terms.html.erb
+++ b/app/views/pages/terms.html.erb
@@ -1,0 +1,28 @@
+<% content_for :title, "Terms of Use | Second Breakfast" %>
+
+<article class="mx-auto max-w-3xl space-y-8 text-gray-700">
+  <header>
+    <h1 class="text-3xl font-bold tracking-tight text-gray-900">Terms of Use</h1>
+    <p class="mt-2 text-sm text-gray-500">Last updated: 5 August 2026</p>
+  </header>
+
+  <section class="space-y-3">
+    <h2 class="text-xl font-semibold text-gray-900">Using Second Breakfast</h2>
+    <p>Second Breakfast is a hobby recipe and meal-planning service. You may use it for lawful, personal purposes and must provide accurate account information and keep your password secure.</p>
+  </section>
+
+  <section class="space-y-3">
+    <h2 class="text-xl font-semibold text-gray-900">Recipe information</h2>
+    <p>Recipes, nutritional details, and ingredient information are provided for general information only. Check ingredients for allergies and use your own judgement when preparing food.</p>
+  </section>
+
+  <section class="space-y-3">
+    <h2 class="text-xl font-semibold text-gray-900">Availability and accounts</h2>
+    <p>The service is provided as available and may change or be interrupted. You may stop using it at any time and can permanently delete your account from the Account page.</p>
+  </section>
+
+  <section class="space-y-3">
+    <h2 class="text-xl font-semibold text-gray-900">Contact</h2>
+    <p>Questions about these terms can be sent to <%= mail_to "stevie@skillfulgorilla.com", class: "font-medium text-indigo-600 hover:text-indigo-500" %>.</p>
+  </section>
+</article>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,26 @@
+<% content_for :title, "Account | Second Breakfast" %>
+
+<section class="mx-auto w-full max-w-2xl">
+  <h1 class="text-3xl font-bold tracking-tight text-gray-900">Account</h1>
+  <p class="mt-2 text-gray-600">Manage a copy of your data or permanently remove your account.</p>
+
+  <div class="mt-8 divide-y divide-gray-200 rounded-lg border border-gray-200 bg-white">
+    <div class="p-6">
+      <h2 class="font-semibold text-gray-900">Export my data</h2>
+      <p class="mt-1 text-sm text-gray-600">Download your account details and saved basket recipes as JSON.</p>
+      <%= link_to "Export my data", account_export_path,
+          class: "mt-4 inline-flex rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500" %>
+    </div>
+
+    <div class="p-6">
+      <h2 class="font-semibold text-gray-900">Delete account</h2>
+      <p class="mt-1 text-sm text-gray-600">Permanently delete your account and all saved basket selections. This cannot be undone.</p>
+      <%= link_to "Delete account", account_path,
+          class: "mt-4 inline-flex rounded-md bg-red-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-red-500",
+          data: {
+            turbo_method: :delete,
+            turbo_confirm: "Are you sure? This permanently deletes your account."
+          } %>
+    </div>
+  </div>
+</section>

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -1,25 +1,59 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Define an application-wide content security policy.
 # See the Securing Rails Applications Guide for more information:
 # https://guides.rubyonrails.org/security.html#content-security-policy-header
 
-# Rails.application.configure do
-#   config.content_security_policy do |policy|
-#     policy.default_src :self, :https
-#     policy.font_src    :self, :https, :data
-#     policy.img_src     :self, :https, :data
-#     policy.object_src  :none
-#     policy.script_src  :self, :https
-#     policy.style_src   :self, :https
-#     # Specify URI for violation reports
-#     # policy.report_uri "/csp-violation-report-endpoint"
-#   end
-#
-#   # Generate session nonces for permitted importmap, inline scripts, and inline styles.
-#   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
-#   config.content_security_policy_nonce_directives = %w(script-src style-src)
-#
-#   # Report violations without enforcing the policy.
-#   # config.content_security_policy_report_only = true
-# end
+Rails.application.configure do
+  config.content_security_policy do |policy|
+    policy.default_src     :self
+    policy.font_src        :self, :data
+    # Recipe images fetched from third-party sites may be served from external URLs.
+    policy.img_src         :self, :data, :https
+    policy.object_src      :none
+    policy.script_src      :self
+    # Trix (Action Text) and Tailwind inject inline styles at runtime.
+    policy.style_src       :self, :unsafe_inline
+    policy.connect_src     :self
+    policy.frame_ancestors :none
+    # Specify URI for violation reports
+    # policy.report_uri "/csp-violation-report-endpoint"
+  end
+
+  # Generate session nonces for permitted importmap and inline scripts.
+  # `javascript_importmap_tags` picks these up automatically.
+  config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s.presence || SecureRandom.base64(16) }
+  config.content_security_policy_nonce_directives = %w[ script-src ]
+
+  # Report violations without enforcing the policy.
+  # config.content_security_policy_report_only = true
+end
+
+# The rswag Swagger UI mounted at /api-docs is a Rack app that renders inline
+# scripts and supplies its own, looser CSP header. Under Rack 3 that header is
+# capitalised while Rails looks for the lowercase name, so Rails does not detect
+# it and would replace it with the app policy above — which blocks the inline
+# bootstrap script and leaves the docs page blank. Drop the app policy for those
+# requests so the engine's own header survives.
+class SwaggerUiContentSecurityPolicyExemption
+  PATH_PREFIX = "/api-docs"
+
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    if env["PATH_INFO"].to_s.start_with?(PATH_PREFIX)
+      env[ActionDispatch::ContentSecurityPolicy::Request::POLICY] = nil
+    end
+
+    @app.call(env)
+  end
+end
+
+Rails.application.config.middleware.insert_before(
+  ActionDispatch::ContentSecurityPolicy::Middleware,
+  SwaggerUiContentSecurityPolicyExemption
+)

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -2,7 +2,10 @@
 
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins "*"
+    # Defaults to permissive for local development; set CORS_ALLOWED_ORIGINS to a
+    # comma-separated list of origins in production to lock this down. The bundled
+    # mcp-server calls the API server-side and does not need CORS.
+    origins ENV.fetch("CORS_ALLOWED_ORIGINS", "*").split(",").map(&:strip)
 
     resource "/api/*",
       headers: :any,

--- a/config/initializers/permissions_policy.rb
+++ b/config/initializers/permissions_policy.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# Be sure to restart your server when you modify this file.
+
+# Define an application-wide HTTP permissions policy. For further
+# information see: https://developers.google.com/web/updates/2018/06/feature-policy
+
+Rails.application.config.permissions_policy do |policy|
+  policy.camera      :none
+  policy.gyroscope   :none
+  policy.microphone  :none
+  policy.usb         :none
+  policy.geolocation :none
+end

--- a/config/initializers/security_headers.rb
+++ b/config/initializers/security_headers.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# Be sure to restart your server when you modify this file.
+
+# Additional browser security headers. X-Frame-Options, X-Content-Type-Options
+# and X-XSS-Protection are already part of Rails' default headers, so they are
+# not repeated here.
+Rails.application.config.action_dispatch.default_headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+
+# Rails' `config.permissions_policy` (see permissions_policy.rb) still emits the
+# legacy `Feature-Policy` header, which current browsers ignore. Send the modern
+# `Permissions-Policy` equivalent as well so the restrictions are actually enforced.
+Rails.application.config.action_dispatch.default_headers["Permissions-Policy"] =
+  "camera=(), gyroscope=(), microphone=(), usb=(), geolocation=()"

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+Rails.application.config.session_store :cookie_store,
+  key: "_second_breakfast_session",
+  expire_after: 2.weeks,
+  httponly: true,
+  same_site: :lax,
+  secure: Rails.env.production?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,12 @@ Rails.application.routes.draw do
   get "sign_in", to: "sessions#new"
   delete "sign_out", to: "sessions#destroy", as: :sign_out
 
+  get "privacy", to: "pages#privacy"
+  get "terms", to: "pages#terms"
+  get "account", to: "users#show", as: :account
+  get "account/export", to: "users#export", as: :account_export
+  delete "account", to: "users#destroy"
+
   get "pages/random_recipe"
   resources :recipes do
     collection do

--- a/spec/jobs/fetch_recipe_image_job_spec.rb
+++ b/spec/jobs/fetch_recipe_image_job_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe FetchRecipeImageJob do
+  subject(:perform_job) { described_class.perform_now(recipe.id) }
+
+  let(:recipe) { create(:recipe, title: "Toast") }
+  let(:token_response) { instance_double(Net::HTTPSuccess, body: 'vqd=token123&') }
+  let(:search_response) do
+    instance_double(Net::HTTPSuccess, body: { results: [ { width: 600, image: "https://example.com/image" } ] }.to_json)
+  end
+
+  def image_response(content_type:, body: "image data")
+    instance_double(Net::HTTPSuccess, body: body).tap do |response|
+      allow(response).to receive(:[]).with("Content-Type").and_return(content_type)
+    end
+  end
+
+  before do
+    allow_any_instance_of(described_class).to receive(:fetch_with_timeout)
+      .and_return(token_response, search_response, downloaded_response)
+  end
+
+  context "with an allowed image response" do
+    let(:downloaded_response) { image_response(content_type: "image/png") }
+
+    it "attaches the downloaded image" do
+      perform_job
+
+      expect(recipe.reload.image).to be_attached
+      expect(recipe.image.blob.content_type).to eq("image/png")
+    end
+  end
+
+  context "with a non-image response" do
+    let(:downloaded_response) { image_response(content_type: "text/html") }
+
+    it "does not attach the response" do
+      expect { perform_job }.not_to raise_error
+
+      expect(recipe.reload.image).not_to be_attached
+    end
+  end
+
+  context "with an unsupported image response" do
+    let(:downloaded_response) { image_response(content_type: "image/svg+xml") }
+
+    it "does not attach the response" do
+      perform_job
+
+      expect(recipe.reload.image).not_to be_attached
+    end
+  end
+end

--- a/spec/models/recipe_spec.rb
+++ b/spec/models/recipe_spec.rb
@@ -27,6 +27,44 @@ RSpec.describe Recipe do
         expect(recipe).to be_valid
       end
     end
+
+    describe "image validation" do
+      it "accepts supported image content types up to 5 MB" do
+        recipe = build(:recipe)
+        recipe.image.attach(io: StringIO.new("image data"), filename: "image.webp", content_type: "image/webp")
+
+        expect(recipe).to be_valid
+      end
+
+      it "rejects unsupported image content types" do
+        recipe = build(:recipe)
+        recipe.image.attach(io: StringIO.new("document"), filename: "document.pdf", content_type: "application/pdf")
+
+        expect(recipe).not_to be_valid
+        expect(recipe.errors[:image]).to include("must be a PNG, JPEG, WebP, or GIF")
+      end
+
+      it "rejects images larger than 5 MB" do
+        blob = ActiveStorage::Blob.create_and_upload!(
+          io: StringIO.new("a" * (5.megabytes + 1)),
+          filename: "large.jpg",
+          content_type: "image/jpeg"
+        )
+        recipe = build(:recipe)
+        recipe.image.attach(blob)
+
+        expect(recipe).not_to be_valid
+        expect(recipe.errors[:image]).to include("must be smaller than 5 MB")
+      end
+    end
+  end
+
+  describe "instruction sanitization" do
+    it "removes executable script tags when rendered" do
+      recipe = build(:recipe, instructions: "Prepare safely<script>alert(1)</script>")
+
+      expect(recipe.instructions.to_s).not_to include("<script")
+    end
   end
 
   describe "associations" do

--- a/spec/requests/api/v1/recipes_spec.rb
+++ b/spec/requests/api/v1/recipes_spec.rb
@@ -126,6 +126,15 @@ RSpec.describe "Api::V1::Recipes", type: :request do
 
         run_test!
       end
+
+      response "200", "SQL metacharacters are treated literally" do
+        let(:query) { "%' OR '1'='1" }
+        before { create(:recipe, title: "Should Not Match") }
+
+        run_test! do |response|
+          expect(response.parsed_body.fetch("recipes")).to be_empty
+        end
+      end
     end
   end
 

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -1,6 +1,22 @@
 require "rails_helper"
 
 RSpec.describe "Pages" do
+  describe "public compliance pages" do
+    it "renders the privacy policy while signed out" do
+      get privacy_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Privacy Policy")
+    end
+
+    it "renders the terms while signed out" do
+      get terms_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Terms of Use")
+    end
+  end
+
   describe "GET / (root)" do
     context "when recipes exist" do
       let!(:recipes) { create_list(:recipe, 5) }

--- a/spec/requests/recipes_spec.rb
+++ b/spec/requests/recipes_spec.rb
@@ -261,5 +261,14 @@ RSpec.describe "Recipes" do
         expect(response).to have_http_status(:ok)
       end
     end
+
+    it "treats SQL metacharacters as literal search text" do
+      expect {
+        get search_recipes_path, params: { query: "%' OR '1'='1" }
+      }.not_to raise_error
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).not_to include("Fluffy Pancakes", "Cheese Omelette")
+    end
   end
 end

--- a/spec/requests/security_headers_spec.rb
+++ b/spec/requests/security_headers_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Security headers" do
+  # ApplicationController uses `allow_browser versions: :modern`, which returns
+  # 406 for user agents it cannot parse as a modern browser.
+  let(:modern_browser_headers) do
+    {
+      "HTTP_USER_AGENT" => "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 " \
+                           "(KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
+    }
+  end
+
+  describe "GET /" do
+    before { get root_path, headers: modern_browser_headers }
+
+    it "responds successfully" do
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "sets a Content-Security-Policy header" do
+      expect(response.headers["Content-Security-Policy"]).to be_present
+    end
+
+    it "restricts the policy to the expected sources" do
+      csp = response.headers["Content-Security-Policy"]
+
+      expect(csp).to include("default-src 'self'")
+      expect(csp).to include("object-src 'none'")
+      expect(csp).to include("frame-ancestors 'none'")
+      expect(csp).to include("connect-src 'self'")
+      expect(csp).to include("img-src 'self' data: https:")
+      expect(csp).to include("font-src 'self' data:")
+      expect(csp).to include("style-src 'self' 'unsafe-inline'")
+    end
+
+    it "nonces the script-src directive so importmap tags are permitted" do
+      csp = response.headers["Content-Security-Policy"]
+
+      expect(csp).to match(/script-src 'self' 'nonce-[^']+'/)
+    end
+
+    it "sets a Permissions-Policy header" do
+      policy = response.headers["Permissions-Policy"]
+
+      expect(policy).to be_present
+      %w[camera gyroscope microphone usb geolocation].each do |feature|
+        expect(policy).to include("#{feature}=()")
+      end
+    end
+
+    it "sets a Referrer-Policy header" do
+      expect(response.headers["Referrer-Policy"]).to eq("strict-origin-when-cross-origin")
+    end
+  end
+
+  describe "GET /api-docs/index.html" do
+    # The Swagger UI is a mounted Rack engine that renders inline scripts and
+    # supplies its own (looser) CSP header, which Rails leaves untouched.
+    before { get "/api-docs/index.html", headers: modern_browser_headers }
+
+    it "still renders" do
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "keeps its own Content-Security-Policy allowing inline scripts" do
+      expect(response.headers["Content-Security-Policy"]).to include("script-src 'self' 'unsafe-inline'")
+    end
+  end
+end

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -54,6 +54,67 @@ RSpec.describe "Sessions" do
         expect(response).to have_http_status(:unprocessable_entity)
       end
     end
+
+    describe "session fixation" do
+      it "issues a new session id when logging in" do
+        # Touching a protected page as a guest establishes a session (flash alert).
+        get new_recipe_path
+        session_id_before = session.id.to_s
+        cookie_before = cookies["_second_breakfast_session"]
+
+        post session_path, params: { email: user.email, password: "password123" }
+
+        expect(session[:user_id]).to eq(user.id)
+        expect(session.id.to_s).not_to eq(session_id_before)
+        expect(cookies["_second_breakfast_session"]).not_to eq(cookie_before)
+      end
+    end
+
+    describe "rate limiting" do
+      include ActiveSupport::Testing::TimeHelpers
+
+      # The test env uses :null_store, whose #increment always returns nil, so the
+      # rate limiter never trips. The limiter captures ActionController::Base.cache_store
+      # at class-load time, so swap that object's counter for a real one here.
+      let(:rate_limit_store) { ActiveSupport::Cache::MemoryStore.new }
+
+      before do
+        allow(ActionController::Base.cache_store).to receive(:increment) do |key, amount = 1, **options|
+          rate_limit_store.increment(key, amount, **options)
+        end
+      end
+
+      it "blocks further attempts once the limit is exceeded" do
+        10.times do
+          post session_path, params: { email: user.email, password: "wrongpassword" }
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+
+        post session_path, params: { email: user.email, password: "wrongpassword" }
+
+        expect(response).to redirect_to(sign_in_path)
+        expect(flash[:alert]).to eq("Too many login attempts. Please try again later.")
+      end
+
+      it "blocks valid credentials too once the limit is exceeded" do
+        10.times { post session_path, params: { email: user.email, password: "wrongpassword" } }
+
+        post session_path, params: { email: user.email, password: "password123" }
+
+        expect(response).to redirect_to(sign_in_path)
+        expect(flash[:alert]).to eq("Too many login attempts. Please try again later.")
+      end
+
+      it "allows attempts again once the window has passed" do
+        11.times { post session_path, params: { email: user.email, password: "wrongpassword" } }
+
+        travel_to 4.minutes.from_now do
+          post session_path, params: { email: user.email, password: "password123" }
+
+          expect(response).to redirect_to(root_path)
+        end
+      end
+    end
   end
 
   describe "DELETE /sign_out" do

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+RSpec.describe "Users" do
+  describe "GET /account/export" do
+    it "requires authentication" do
+      get account_export_path
+
+      expect(response).to redirect_to(sign_in_path)
+    end
+
+    it "downloads the signed-in user's account data as JSON" do
+      user = create(:user)
+      baskets = create_list(:basket, 2, user: user)
+      sign_in(user)
+
+      get account_export_path
+
+      data = response.parsed_body
+      expect(response).to have_http_status(:ok)
+      expect(response.media_type).to eq("application/json")
+      expect(response.headers["Content-Disposition"]).to include("attachment")
+      expect(data).to include("email" => user.email, "created_at" => user.created_at.as_json)
+      expect(data["basket_recipes"]).to match_array(
+        baskets.map { |basket| { "id" => basket.recipe.id, "title" => basket.recipe.title } }
+      )
+    end
+  end
+
+  describe "DELETE /account" do
+    it "destroys the user and baskets, then clears the session" do
+      user = create(:user)
+      create_list(:basket, 2, user: user)
+      sign_in(user)
+
+      expect do
+        delete account_path
+      end.to change(User, :count).by(-1).and change(Basket, :count).by(-2)
+
+      expect(response).to redirect_to(root_path)
+      expect(flash[:notice]).to eq("Your account has been deleted")
+
+      get account_export_path
+      expect(response).to redirect_to(sign_in_path)
+    end
+  end
+end

--- a/spec/system/security_headers_spec.rb
+++ b/spec/system/security_headers_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Content Security Policy", type: :system do
+  it "allows the importmap and Stimulus to boot on the app itself" do
+    create(:recipe)
+
+    visit root_path
+
+    # `javascript_importmap_tags` renders a nonced inline importmap; if the CSP
+    # blocked it, no Stimulus controller would ever connect.
+    expect(page).to have_css("script[type='importmap'][nonce]", visible: :hidden)
+    expect(page.evaluate_script("typeof window.Stimulus")).not_to eq("undefined")
+  end
+
+  it "does not break the Swagger UI at /api-docs" do
+    visit "/api-docs/index.html"
+
+    # Swagger UI bootstraps from an inline <script>. It only renders this node if
+    # that script was permitted to run, so this fails if the app CSP leaks in.
+    expect(page).to have_css("#swagger-ui .swagger-ui")
+  end
+end


### PR DESCRIPTION
## Summary

Implements the security-hardening checklist from #73. Items already covered before this PR: `force_ssl`/HSTS in production, Brakeman + importmap audit in CI, httpOnly cookies (Rails default), parameterized queries.

- **Auth**: Rails 8 built-in `rate_limit` on login (10 attempts / 3 min), `User.authenticate_by` (timing-safe, no user enumeration), `reset_session` on login/logout (session fixation), failed-login warn logging, session cookie `expire_after: 2.weeks` + explicit `httponly`/`same_site: :lax`/`secure` settings
- **Headers**: Content-Security-Policy with script-src nonces (importmap-compatible, Swagger UI verified), Permissions-Policy, Referrer-Policy; CORS origins now restrictable via `CORS_ALLOWED_ORIGINS` env
- **Input**: Recipe image upload validation (type allowlist + 5 MB cap), content-type check in `FetchRecipeImageJob`, SQL-injection regression specs on search, ActionText XSS regression spec
- **Infra**: Dependabot config (bundler, GitHub Actions, mcp-server npm), `SECURITY.md`
- **Compliance**: Privacy policy & terms pages, GDPR data export (JSON download) and account deletion with cascade to baskets

## Test plan

- [x] `bin/rails tailwindcss:build && bundle exec rspec` — full suite including new request/system specs
- [x] `bundle exec rubocop` — clean
- [ ] `bin/brakeman --no-pager` — no warnings
- [x] Manual: 11th rapid login attempt is rejected; `/privacy`, `/terms`, `/api-docs` render; CSP header present and app JS (importmap/Turbo/Stimulus dropdown) still works; account export downloads JSON; account deletion removes user + baskets and logs out

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #73

⚔ orchestrated by thrawn