### PR TITLE
🔒 Replace inline ingredient/print JS with Stimulus controllers

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,7 +86,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.24.6)
       msgpack (~> 1.2)
-    brakeman (8.0.5)
+    brakeman (8.0.6)
       racc
     builder (3.3.0)
     capybara (3.40.0)

--- a/app/javascript/controllers/ingredients_controller.js
+++ b/app/javascript/controllers/ingredients_controller.js
@@ -1,0 +1,14 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Manages the dynamic ingredient rows on the recipe form.
+export default class extends Controller {
+  static targets = ["list", "template"]
+
+  add() {
+    this.listTarget.append(this.templateTarget.content.cloneNode(true))
+  }
+
+  remove(event) {
+    event.currentTarget.parentElement.remove()
+  }
+}

--- a/app/javascript/controllers/print_controller.js
+++ b/app/javascript/controllers/print_controller.js
@@ -1,0 +1,7 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  print() {
+    window.print()
+  }
+}

--- a/app/views/meals/index.html.erb
+++ b/app/views/meals/index.html.erb
@@ -10,7 +10,7 @@
     </div>
     <% if @baskets.any? %>
       <div class="flex gap-x-2">
-        <button onclick="window.print()" class="inline-flex items-center gap-x-1.5 rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50">
+        <button data-controller="print" data-action="print#print" class="inline-flex items-center gap-x-1.5 rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50">
           <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" d="M6.72 13.829c-.24.03-.48.062-.72.096m.72-.096a42.415 42.415 0 0110.56 0m-10.56 0L6.34 18m10.94-4.171c.24.03.48.062.72.096m-.72-.096L17.66 18m0 0l.229 2.523a1.125 1.125 0 01-1.12 1.227H7.231c-.662 0-1.18-.568-1.12-1.227L6.34 18m11.318 0h1.091A2.25 2.25 0 0021 15.75V9.456c0-1.081-.768-2.015-1.837-2.175a48.055 48.055 0 00-1.913-.247M6.34 18H5.25A2.25 2.25 0 013 15.75V9.456c0-1.081.768-2.015 1.837-2.175a48.041 48.041 0 011.913-.247m10.5 0a48.536 48.536 0 00-10.5 0m10.5 0V3.375c0-.621-.504-1.125-1.125-1.125h-8.25c-.621 0-1.125.504-1.125 1.125v3.659M18 10.5h.008v.008H18V10.5zm-3 0h.008v.008H15V10.5z" />
           </svg>

--- a/app/views/recipes/_form.html.erb
+++ b/app/views/recipes/_form.html.erb
@@ -43,16 +43,16 @@
 </div>
 
   <!-- Ingredients Section -->
-  <div class="my-5">
+  <div class="my-5" data-controller="ingredients">
     <%= form.label :ingredients %>
-    <div id="ingredients" class="mt-2">
+    <div id="ingredients" class="mt-2" data-ingredients-target="list">
       <!-- Template for new ingredients -->
-      <template id="ingredient-template">
+      <template data-ingredients-target="template">
         <div class="flex gap-2 mb-2">
           <input type="text" name="recipe[ingredients][][name]" placeholder="Name" class="shadow rounded-md border px-3 py-2 flex-grow">
           <input type="number" name="recipe[ingredients][][quantity]" placeholder="Quantity" class="shadow rounded-md border px-3 py-2 w-24">
           <input type="text" name="recipe[ingredients][][unit]" placeholder="Unit" class="shadow rounded-md border px-3 py-2 w-24">
-          <button type="button" onclick="this.parentElement.remove()" class="px-3 py-2 bg-red-600 text-white rounded-md">Remove</button>
+          <button type="button" data-action="ingredients#remove" class="px-3 py-2 bg-red-600 text-white rounded-md">Remove</button>
         </div>
       </template>
 
@@ -63,24 +63,14 @@
             <input type="text" name="recipe[ingredients][][name]" value="<%= ingredient['name'] %>" placeholder="Name" class="shadow rounded-md border px-3 py-2 flex-grow">
             <input type="number" name="recipe[ingredients][][quantity]" value="<%= ingredient['quantity'] %>" placeholder="Quantity" class="shadow rounded-md border px-3 py-2 w-24">
             <input type="text" name="recipe[ingredients][][unit]" value="<%= ingredient['unit'] %>" placeholder="Unit" class="shadow rounded-md border px-3 py-2 w-24">
-            <button type="button" onclick="this.parentElement.remove()" class="px-3 py-2 bg-red-600 text-white rounded-md">Remove</button>
+            <button type="button" data-action="ingredients#remove" class="px-3 py-2 bg-red-600 text-white rounded-md">Remove</button>
           </div>
         <% end %>
       <% end %>
     </div>
 
     <!-- Add Ingredient Button -->
-    <button type="button" onclick="addIngredient()" class="mt-2 px-3 py-2 bg-green-600 text-white rounded-md">Add Ingredient</button>
-
-    <!-- Script for adding ingredients dynamically -->
-    <script>
-      function addIngredient() {
-        const template = document.getElementById('ingredient-template');
-        const ingredientsDiv = document.getElementById('ingredients');
-        const clone = template.content.cloneNode(true);
-        ingredientsDiv.appendChild(clone);
-      }
-    </script>
+    <button type="button" data-action="ingredients#add" class="mt-2 px-3 py-2 bg-green-600 text-white rounded-md">Add Ingredient</button>
   </div>
 
   <!-- Other Fields (Prep Time, Nutrition, etc.) -->

--- a/spec/system/recipes_spec.rb
+++ b/spec/system/recipes_spec.rb
@@ -52,6 +52,19 @@ RSpec.describe "Recipes", type: :system do
       expect(page).to have_field("Title")
     end
 
+    it "can add and remove ingredient rows on the new recipe form" do
+      visit new_recipe_path
+
+      expect(page).to have_no_field("recipe[ingredients][][name]", type: "text")
+
+      click_button "Add Ingredient"
+      click_button "Add Ingredient"
+      expect(page).to have_field("recipe[ingredients][][name]", type: "text", count: 2)
+
+      first("button", text: "Remove").click
+      expect(page).to have_field("recipe[ingredients][][name]", type: "text", count: 1)
+    end
+
     context "with an existing recipe" do
       let!(:recipe) { create(:recipe, title: "Old Title") }
 


### PR DESCRIPTION
## Summary
The nonce-based CSP (`script-src 'self' 'nonce-...'`) blocks inline `<script>` tags and `onclick=` handlers, which broke two things in production:

- **Add/Remove Ingredient** on the recipe form (inline `addIngredient()` script + `onclick` handlers)
- **Print** button on the meal plan page (`onclick="window.print()"`)

Both now use Stimulus controllers (`ingredients_controller`, `print_controller`), auto-loaded via the existing `pin_all_from` importmap setup. No CSP changes needed.

> Local dev looks fine only if the server was booted before the CSP initializer landed — restart `bin/dev` and the old inline version breaks there too.

Also bumps Brakeman to 8.0.6 (same `--ensure-latest` fix as #128/#129 — whichever lands first, the rest still merge cleanly).

## Testing
- New system spec covers adding two ingredient rows and removing one — system specs run in headless Chrome with the real CSP enforced, so this guards the regression
- 238 specs pass, RuboCop clean, Brakeman 8.0.6 clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)