### PR TITLE
🔐 API keys: hashed revocable keys, full API auth, account UI (#135)

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Create recipes programmatically via the API. Requires authentication.
 
 ```bash
 curl -X POST http://localhost:3000/api/v1/recipes \
-  -H "Authorization: Bearer your-token" \
+  -H "Authorization: Bearer sb_your_api_key" \
   -H "Content-Type: application/json" \
   -d '{
     "recipe": {
@@ -155,31 +155,30 @@ Interactive API documentation available at [/api-docs](/api-docs) (Swagger UI).
 
 | Method | Path | Auth | Description |
 |--------|------|------|-------------|
-| GET | `/api/v1/recipes` | No | List recipes (paginated) |
-| GET | `/api/v1/recipes/:id` | No | Show recipe |
-| GET | `/api/v1/recipes/search?query=` | No | Search recipes |
+| GET | `/api/v1/recipes` | Yes | List recipes (paginated) |
+| GET | `/api/v1/recipes/:id` | Yes | Show recipe |
+| GET | `/api/v1/recipes/search?query=` | Yes | Search recipes |
 | POST | `/api/v1/recipes` | Yes | Create recipe |
 | PUT | `/api/v1/recipes/:id` | Yes | Update recipe |
 | DELETE | `/api/v1/recipes/:id` | Yes | Delete recipe |
-| GET | `/api/v1/categories` | No | List categories |
-| GET | `/api/v1/categories/:id` | No | Category with recipes |
+| GET | `/api/v1/categories` | Yes | List categories |
+| GET | `/api/v1/categories/:id` | Yes | Category with recipes |
 | GET | `/api/v1/baskets` | Yes | User's basket |
 | POST | `/api/v1/baskets` | Yes | Add recipe to basket |
 | DELETE | `/api/v1/baskets/:id` | Yes | Remove from basket |
 
 ### Authentication
 
-Authenticated endpoints require a Bearer token in the Authorization header:
+**Every** endpoint requires an API key sent as a Bearer token:
 
 ```
-Authorization: Bearer your_api_token
+Authorization: Bearer sb_your_api_key
 ```
 
-Generate an API token via the Rails console:
-```ruby
-user = User.find_by(email: "your@email.com")
-user.generate_api_token!
-```
+Create a key from the **Account** page (`/account`, API Keys section): name it,
+click **Create key**, and copy the `sb_...` token — it is shown exactly once and
+cannot be retrieved again. Revoke keys from the same page; revocation takes
+effect immediately.
 
 ## MCP Server (Claude Integration)
 

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -5,6 +5,8 @@ module Api
     class BaseController < ActionController::API
       include Pagy::Backend
 
+      before_action :authenticate_api_token!
+
       rescue_from ActiveRecord::RecordNotFound, with: :not_found
       rescue_from ActiveRecord::RecordInvalid, with: :unprocessable_entity
       rescue_from Pagy::OverflowError, with: :page_not_found
@@ -13,9 +15,16 @@ module Api
 
       def authenticate_api_token!
         token = request.headers["Authorization"]&.split(" ")&.last
-        @current_user = User.find_by(api_token: token) if token.present?
+        api_key = ApiKey.authenticate(token)
 
-        render json: { error: "Unauthorized" }, status: :unauthorized unless @current_user
+        if api_key
+          @current_api_key = api_key
+          @current_user = api_key.user
+          api_key.touch_last_used!
+        else
+          response.set_header("WWW-Authenticate", "Bearer")
+          render json: { error: "Unauthorized" }, status: :unauthorized
+        end
       end
 
       def current_user

--- a/app/controllers/api/v1/baskets_controller.rb
+++ b/app/controllers/api/v1/baskets_controller.rb
@@ -3,8 +3,6 @@
 module Api
   module V1
     class BasketsController < BaseController
-      before_action :authenticate_api_token!
-
       def index
         @baskets = current_user.baskets.includes(recipe: :category)
       end

--- a/app/controllers/api/v1/recipes_controller.rb
+++ b/app/controllers/api/v1/recipes_controller.rb
@@ -3,7 +3,6 @@
 module Api
   module V1
     class RecipesController < BaseController
-      before_action :authenticate_api_token!, only: [ :create, :update, :destroy ]
       before_action :set_recipe, only: [ :show, :update, :destroy ]
 
       def index

--- a/app/controllers/api_keys_controller.rb
+++ b/app/controllers/api_keys_controller.rb
@@ -1,0 +1,28 @@
+class ApiKeysController < ApplicationController
+  before_action :authenticate_user!
+
+  def create
+    api_key = current_user.api_keys.new(api_key_params)
+
+    if api_key.save
+      # Flash is the one-time channel: gone after the next request, so the
+      # raw token can never be re-rendered.
+      flash[:new_api_key_token] = api_key.token
+      flash[:new_api_key_name] = api_key.name
+      redirect_to account_path
+    else
+      redirect_to account_path, alert: api_key.errors.full_messages.to_sentence
+    end
+  end
+
+  def destroy
+    current_user.api_keys.find(params[:id]).revoke!
+    redirect_to account_path, notice: "API key revoked"
+  end
+
+  private
+
+  def api_key_params
+    params.require(:api_key).permit(:name)
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,11 +1,12 @@
 class UsersController < ApplicationController
-  before_action :authenticate_user!, only: [ :export, :destroy ]
+  before_action :authenticate_user!, only: [ :show, :export, :destroy ]
 
   def new
     @user = User.new
   end
 
   def show
+    @api_keys = current_user.api_keys.order(created_at: :desc)
   end
 
   def export
@@ -14,6 +15,15 @@ class UsersController < ApplicationController
       created_at: current_user.created_at,
       basket_recipes: current_user.baskets.includes(:recipe).map do |basket|
         { id: basket.recipe.id, title: basket.recipe.title }
+      end,
+      api_keys: current_user.api_keys.map do |key|
+        {
+          name: key.name,
+          prefix: key.prefix,
+          created_at: key.created_at,
+          last_used_at: key.last_used_at,
+          revoked_at: key.revoked_at
+        }
       end
     }
 

--- a/app/javascript/controllers/clipboard_controller.js
+++ b/app/javascript/controllers/clipboard_controller.js
@@ -2,16 +2,12 @@ import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
   static targets = ["content", "button", "text", "icon"]
+  static values = { text: String }
 
   async copy() {
-    const content = this.contentTarget
-    const items = content.querySelectorAll("li")
-
-    const text = Array.from(items).map(li => {
-      const name = li.querySelector("span:first-child")?.textContent?.trim() || ""
-      const quantity = li.querySelector("span:last-child")?.textContent?.trim() || ""
-      return `${name}: ${quantity}`
-    }).join("\n")
+    const text = this.hasTextValue && this.textValue !== ""
+      ? this.textValue
+      : this.ingredientsText()
 
     try {
       await navigator.clipboard.writeText(text)
@@ -28,6 +24,16 @@ export default class extends Controller {
       document.body.removeChild(textarea)
       this.showCopied()
     }
+  }
+
+  ingredientsText() {
+    const items = this.contentTarget.querySelectorAll("li")
+
+    return Array.from(items).map(li => {
+      const name = li.querySelector("span:first-child")?.textContent?.trim() || ""
+      const quantity = li.querySelector("span:last-child")?.textContent?.trim() || ""
+      return `${name}: ${quantity}`
+    }).join("\n")
   }
 
   showCopied() {

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+class ApiKey < ApplicationRecord
+  TOUCH_INTERVAL = 1.minute
+
+  belongs_to :user
+
+  validates :name, presence: true
+
+  scope :active, -> { where(revoked_at: nil) }
+
+  # The raw token is only readable on the freshly created instance —
+  # it is never persisted and cannot be recovered later.
+  attr_reader :token
+
+  before_validation :generate_token, on: :create
+
+  def self.authenticate(raw)
+    return nil if raw.blank?
+
+    active.find_by(token_digest: Digest::SHA256.hexdigest(raw))
+  end
+
+  def active?
+    revoked_at.nil?
+  end
+
+  def revoke!
+    update!(revoked_at: Time.current)
+  end
+
+  def touch_last_used!
+    return if last_used_at.present? && last_used_at > TOUCH_INTERVAL.ago
+
+    update_column(:last_used_at, Time.current)
+  end
+
+  private
+
+  def generate_token
+    return if token_digest.present?
+
+    @token = "sb_#{SecureRandom.hex(32)}"
+    self.token_digest = Digest::SHA256.hexdigest(@token)
+    self.prefix = @token.first(8)
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,13 +3,9 @@ class User < ApplicationRecord
 
   has_many :baskets, dependent: :destroy
   has_many :recipes, through: :baskets
+  has_many :api_keys, dependent: :destroy
 
   validates :email, presence: true, uniqueness: true
-
-  def generate_api_token!
-    update!(api_token: SecureRandom.hex(32))
-    api_token
-  end
 
   def in_basket?(recipe)
     baskets.exists?(recipe: recipe)

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -13,6 +13,70 @@
     </div>
 
     <div class="p-6">
+      <h2 class="font-semibold text-gray-900">API keys</h2>
+      <p class="mt-1 text-sm text-gray-600">Keys grant full access to the JSON API. Treat them like passwords.</p>
+
+      <% if flash[:new_api_key_token].present? %>
+        <div class="mt-4 rounded-md border border-indigo-200 bg-indigo-50 p-4"
+             data-controller="clipboard"
+             data-clipboard-text-value="<%= flash[:new_api_key_token] %>">
+          <p class="text-sm font-medium text-indigo-900">
+            Key &ldquo;<%= flash[:new_api_key_name] %>&rdquo; created. Copy it now &mdash; it will not be shown again.
+          </p>
+          <div class="mt-2 flex items-center gap-x-2">
+            <code class="block overflow-x-auto rounded bg-white px-2 py-1 text-sm text-gray-900 ring-1 ring-inset ring-indigo-200"><%= flash[:new_api_key_token] %></code>
+            <button type="button" data-action="clipboard#copy"
+                    class="inline-flex items-center gap-x-1.5 rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500">
+              <svg data-clipboard-target="icon" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M15.666 3.888A2.25 2.25 0 0013.5 2.25h-3c-1.03 0-1.9.693-2.166 1.638m7.332 0c.055.194.084.4.084.612v0a.75.75 0 01-.75.75H9a.75.75 0 01-.75-.75v0c0-.212.03-.418.084-.612m7.332 0c.646.049 1.288.11 1.927.184 1.1.128 1.907 1.077 1.907 2.185V19.5a2.25 2.25 0 01-2.25 2.25H6.75A2.25 2.25 0 014.5 19.5V6.257c0-1.108.806-2.057 1.907-2.185a48.208 48.208 0 011.927-.184" />
+              </svg>
+              <span data-clipboard-target="text">Copy</span>
+            </button>
+          </div>
+        </div>
+      <% end %>
+
+      <%= form_with url: api_keys_path, scope: :api_key, class: "mt-4 flex items-end gap-x-2" do |form| %>
+        <div class="flex-grow">
+          <%= form.label :name, "Key name", class: "block text-sm font-medium text-gray-700" %>
+          <%= form.text_field :name, placeholder: "e.g. MCP server", required: true,
+              class: "mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm" %>
+        </div>
+        <%= form.submit "Create key",
+            class: "rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 cursor-pointer" %>
+      <% end %>
+
+      <% if @api_keys.any? %>
+        <ul class="mt-4 divide-y divide-gray-100">
+          <% @api_keys.each do |key| %>
+            <li class="flex items-center justify-between gap-x-4 py-3">
+              <div>
+                <p class="text-sm font-medium <%= key.active? ? "text-gray-900" : "text-gray-400 line-through" %>">
+                  <%= key.name %>
+                </p>
+                <p class="mt-1 text-xs text-gray-500">
+                  <code><%= key.prefix %>&hellip;</code>
+                  &middot; Created <%= key.created_at.to_date %>
+                  &middot; Last used <%= key.last_used_at ? key.last_used_at.to_date : "Never" %>
+                </p>
+              </div>
+              <% if key.active? %>
+                <%= link_to "Revoke", api_key_path(key),
+                    class: "rounded-md bg-red-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-red-500",
+                    data: {
+                      turbo_method: :delete,
+                      turbo_confirm: "Revoke this key? Clients using it will stop working immediately."
+                    } %>
+              <% else %>
+                <span class="inline-flex items-center rounded-full bg-gray-100 px-2 py-1 text-xs font-medium text-gray-600">Revoked</span>
+              <% end %>
+            </li>
+          <% end %>
+        </ul>
+      <% end %>
+    </div>
+
+    <div class="p-6">
       <h2 class="font-semibold text-gray-900">Delete account</h2>
       <p class="mt-1 text-sm text-gray-600">Permanently delete your account and all saved basket selections. This cannot be undone.</p>
       <%= link_to "Delete account", account_path,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,7 @@ Rails.application.routes.draw do
   get "account", to: "users#show", as: :account
   get "account/export", to: "users#export", as: :account_export
   delete "account", to: "users#destroy"
+  resources :api_keys, only: [ :create, :destroy ]
 
   get "pages/random_recipe"
   resources :recipes do

--- a/db/migrate/20260816195713_create_api_keys.rb
+++ b/db/migrate/20260816195713_create_api_keys.rb
@@ -1,0 +1,15 @@
+class CreateApiKeys < ActiveRecord::Migration[8.1]
+  def change
+    create_table :api_keys do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :name, null: false
+      t.string :token_digest, null: false
+      t.string :prefix, null: false
+      t.datetime :last_used_at
+      t.datetime :revoked_at
+
+      t.timestamps
+    end
+    add_index :api_keys, :token_digest, unique: true
+  end
+end

--- a/db/migrate/20260816195714_backfill_legacy_api_keys.rb
+++ b/db/migrate/20260816195714_backfill_legacy_api_keys.rb
@@ -1,0 +1,25 @@
+class BackfillLegacyApiKeys < ActiveRecord::Migration[8.1]
+  # Inline models so the migration keeps working however the app models evolve.
+  class MigrationUser < ActiveRecord::Base
+    self.table_name = "users"
+  end
+
+  class MigrationApiKey < ActiveRecord::Base
+    self.table_name = "api_keys"
+  end
+
+  def up
+    MigrationUser.where.not(api_token: nil).find_each do |user|
+      MigrationApiKey.create!(
+        user_id: user.id,
+        name: "Legacy key",
+        token_digest: Digest::SHA256.hexdigest(user.api_token),
+        prefix: user.api_token[0, 8]
+      )
+    end
+  end
+
+  def down
+    MigrationApiKey.where(name: "Legacy key").delete_all
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_31_145325) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_16_195714) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -50,6 +50,19 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_31_145325) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "api_keys", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "last_used_at"
+    t.string "name", null: false
+    t.string "prefix", null: false
+    t.datetime "revoked_at"
+    t.string "token_digest", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["token_digest"], name: "index_api_keys_on_token_digest", unique: true
+    t.index ["user_id"], name: "index_api_keys_on_user_id"
   end
 
   create_table "baskets", force: :cascade do |t|
@@ -93,6 +106,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_31_145325) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "api_keys", "users"
   add_foreign_key "baskets", "recipes"
   add_foreign_key "baskets", "users"
   add_foreign_key "recipes", "categories"

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -16,16 +16,17 @@ The server requires two environment variables:
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `API_URL` | Second Breakfast API base URL | `http://localhost:3000/api/v1` |
-| `API_TOKEN` | Your API authentication token | (required for write operations) |
+| `API_TOKEN` | Your API key | (required) |
 
-### Getting an API Token
+**Every** operation — including reads and search — requires the key; the server exits at startup if `API_TOKEN` is missing.
 
-```ruby
-# In Rails console (bin/rails console)
-user = User.find_by(email: "your@email.com")
-user.generate_api_token!
-# => "abc123..." (copy this token)
-```
+### Getting an API Key
+
+1. Sign in to Second Breakfast and open **Account** (`/account`)
+2. In the **API Keys** section, give the key a name (e.g. "MCP server") and click **Create key**
+3. Copy the `sb_...` token — it is shown **exactly once** and cannot be retrieved again
+
+Keys can be revoked from the same page at any time.
 
 ## Usage with Claude Desktop
 
@@ -144,7 +145,7 @@ already have a similar one, and only create it if we don't.
 ### "Unauthorized" error
 
 - Check that `API_TOKEN` is set correctly
-- Verify the token is valid: `User.find_by(api_token: "your-token")`
+- Check the key hasn't been revoked on the Account page (`/account`, API Keys section) — if it has, create a new one there
 
 ### Server not connecting
 

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -7,16 +7,21 @@ import { z } from "zod";
 const API_URL = process.env.API_URL || "http://localhost:3000/api/v1";
 const API_TOKEN = process.env.API_TOKEN || "";
 
+if (!API_TOKEN) {
+  console.error(
+    "API_TOKEN is required — every API operation needs it. " +
+    "Create an API key in Second Breakfast under Account -> API Keys (/account)."
+  );
+  process.exit(1);
+}
+
 async function apiRequest(method, path, body = null) {
   const url = `${API_URL}${path}`;
   const headers = {
     "Content-Type": "application/json",
     "Accept": "application/json",
+    "Authorization": `Bearer ${API_TOKEN}`,
   };
-
-  if (API_TOKEN) {
-    headers["Authorization"] = `Bearer ${API_TOKEN}`;
-  }
 
   const options = { method, headers };
   if (body) {
@@ -25,6 +30,12 @@ async function apiRequest(method, path, body = null) {
 
   const response = await fetch(url, options);
   const data = await response.json();
+
+  if (response.status === 401) {
+    throw new Error(
+      "API key invalid or revoked — create a new one in Second Breakfast under Account -> API Keys (/account)."
+    );
+  }
 
   if (!response.ok) {
     throw new Error(data.error || data.errors?.join(", ") || "API request failed");

--- a/spec/factories/api_keys.rb
+++ b/spec/factories/api_keys.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :api_key do
+    association :user
+    sequence(:name) { |n| "Key #{n}" }
+
+    trait :revoked do
+      revoked_at { 1.hour.ago }
+    end
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -4,10 +4,6 @@ FactoryBot.define do
     password { "password123" }
     password_confirmation { "password123" }
 
-    trait :with_api_token do
-      api_token { SecureRandom.hex(32) }
-    end
-
     trait :with_basket do
       transient do
         recipes_count { 1 }

--- a/spec/migrations/backfill_legacy_api_keys_spec.rb
+++ b/spec/migrations/backfill_legacy_api_keys_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require Rails.root.glob("db/migrate/*_backfill_legacy_api_keys.rb").sole
+
+RSpec.describe BackfillLegacyApiKeys do
+  let(:migration) { described_class.new }
+
+  it "backfills users.api_token values as authenticatable legacy keys" do
+    legacy_token = SecureRandom.hex(32)
+    user = create(:user)
+    user.update_column(:api_token, legacy_token)
+
+    ActiveRecord::Migration.suppress_messages { migration.up }
+
+    key = ApiKey.authenticate(legacy_token)
+    expect(key).to be_present
+    expect(key.user).to eq(user)
+    expect(key.name).to eq("Legacy key")
+    expect(key.prefix).to eq(legacy_token[0, 8])
+  end
+
+  it "skips users without a legacy token" do
+    create(:user)
+
+    expect {
+      ActiveRecord::Migration.suppress_messages { migration.up }
+    }.not_to change(ApiKey, :count)
+  end
+end

--- a/spec/models/api_key_spec.rb
+++ b/spec/models/api_key_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ApiKey, type: :model do
+  describe "token generation" do
+    let(:api_key) { create(:api_key) }
+
+    it "exposes an sb_-prefixed raw token on the fresh instance" do
+      expect(api_key.token).to match(/\Asb_[0-9a-f]{64}\z/)
+    end
+
+    it "persists only the SHA-256 digest, never the raw token" do
+      raw = api_key.token
+
+      persisted_values = ApiKey.connection.select_one(
+        ApiKey.sanitize_sql([ "SELECT * FROM api_keys WHERE id = ?", api_key.id ])
+      ).values
+
+      expect(persisted_values).not_to include(raw)
+      expect(api_key.token_digest).to eq(Digest::SHA256.hexdigest(raw))
+    end
+
+    it "does not expose the raw token after reload" do
+      expect(described_class.find(api_key.id).token).to be_nil
+    end
+
+    it "derives the prefix from the first 8 characters of the token" do
+      expect(api_key.prefix).to eq(api_key.token.first(8))
+      expect(api_key.prefix).to start_with("sb_")
+    end
+
+    it "requires a name" do
+      expect(build(:api_key, name: nil)).not_to be_valid
+    end
+  end
+
+  describe ".authenticate" do
+    let!(:api_key) { create(:api_key) }
+
+    it "returns the key for a valid raw token" do
+      expect(described_class.authenticate(api_key.token)).to eq(api_key)
+    end
+
+    it "returns nil for an unknown token" do
+      expect(described_class.authenticate("sb_#{SecureRandom.hex(32)}")).to be_nil
+    end
+
+    it "returns nil for a revoked key's token" do
+      raw = api_key.token
+      api_key.revoke!
+
+      expect(described_class.authenticate(raw)).to be_nil
+    end
+
+    it "returns nil for nil or blank tokens" do
+      expect(described_class.authenticate(nil)).to be_nil
+      expect(described_class.authenticate("")).to be_nil
+    end
+  end
+
+  describe "#revoke! and #active?" do
+    let(:api_key) { create(:api_key) }
+
+    it "is active until revoked" do
+      expect(api_key).to be_active
+
+      api_key.revoke!
+
+      expect(api_key).not_to be_active
+      expect(api_key.revoked_at).to be_present
+    end
+
+    it "drops out of the active scope when revoked" do
+      api_key.revoke!
+
+      expect(described_class.active).not_to include(api_key)
+    end
+  end
+
+  describe "#touch_last_used!" do
+    let(:api_key) { create(:api_key) }
+
+    it "stamps last_used_at when never used" do
+      expect { api_key.touch_last_used! }.to change { api_key.reload.last_used_at }.from(nil)
+    end
+
+    it "does not stamp again within the throttle interval" do
+      api_key.touch_last_used!
+
+      expect { api_key.touch_last_used! }.not_to change { api_key.reload.last_used_at }
+    end
+
+    it "stamps again once the throttle interval has passed" do
+      api_key.update_column(:last_used_at, 2.minutes.ago)
+
+      expect { api_key.touch_last_used! }.to change { api_key.reload.last_used_at }
+    end
+  end
+end

--- a/spec/requests/api/v1/authentication_spec.rb
+++ b/spec/requests/api/v1/authentication_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Api::V1 authentication", type: :request do
+  let(:api_key) { create(:api_key) }
+  let(:recipe) { create(:recipe) }
+  let(:category) { create(:category) }
+
+  shared_examples "a protected endpoint" do |method, path_proc|
+    let(:path) { instance_exec(&path_proc) }
+    let(:json_headers) { { "Accept" => "application/json" } }
+
+    it "returns 401 with no Authorization header" do
+      public_send(method, path, headers: json_headers)
+
+      expect(response).to have_http_status(:unauthorized)
+      expect(response.headers["WWW-Authenticate"]).to eq("Bearer")
+      expect(response.parsed_body).to eq("error" => "Unauthorized")
+    end
+
+    it "returns 401 with a garbage token" do
+      public_send(method, path, headers: json_headers.merge("Authorization" => "Bearer garbage"))
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "returns 401 with a revoked key" do
+      raw = api_key.token
+      api_key.revoke!
+
+      public_send(method, path, headers: json_headers.merge("Authorization" => "Bearer #{raw}"))
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "authenticates with a valid key" do
+      public_send(method, path, headers: json_headers.merge("Authorization" => "Bearer #{api_key.token}"))
+
+      expect(response).not_to have_http_status(:unauthorized)
+    end
+  end
+
+  describe "GET /api/v1/recipes" do
+    include_examples "a protected endpoint", :get, -> { "/api/v1/recipes" }
+  end
+
+  describe "GET /api/v1/recipes/search" do
+    include_examples "a protected endpoint", :get, -> { "/api/v1/recipes/search?query=x" }
+  end
+
+  describe "GET /api/v1/recipes/:id" do
+    include_examples "a protected endpoint", :get, -> { "/api/v1/recipes/#{recipe.id}" }
+  end
+
+  describe "GET /api/v1/categories" do
+    include_examples "a protected endpoint", :get, -> { "/api/v1/categories" }
+  end
+
+  describe "GET /api/v1/categories/:id" do
+    include_examples "a protected endpoint", :get, -> { "/api/v1/categories/#{category.id}" }
+  end
+
+  describe "GET /api/v1/baskets" do
+    include_examples "a protected endpoint", :get, -> { "/api/v1/baskets" }
+  end
+
+  describe "usage tracking" do
+    it "stamps the key's last_used_at on a successful request" do
+      expect {
+        get "/api/v1/recipes", headers: { "Authorization" => "Bearer #{api_key.token}" }
+      }.to change { api_key.reload.last_used_at }.from(nil)
+    end
+  end
+
+  describe "the web UI" do
+    it "still uses session auth, untouched by API key auth" do
+      get "/recipes"
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end

--- a/spec/requests/api/v1/baskets_spec.rb
+++ b/spec/requests/api/v1/baskets_spec.rb
@@ -3,8 +3,9 @@
 require "swagger_helper"
 
 RSpec.describe "Api::V1::Baskets", type: :request do
-  let(:user) { create(:user, :with_api_token) }
-  let(:Authorization) { "Bearer #{user.api_token}" }
+  let(:api_key) { create(:api_key) }
+  let(:user) { api_key.user }
+  let(:Authorization) { "Bearer #{api_key.token}" }
 
   path "/api/v1/baskets" do
     get "List basket items" do

--- a/spec/requests/api/v1/categories_spec.rb
+++ b/spec/requests/api/v1/categories_spec.rb
@@ -3,10 +3,14 @@
 require "swagger_helper"
 
 RSpec.describe "Api::V1::Categories", type: :request do
+  let(:api_key) { create(:api_key) }
+  let(:Authorization) { "Bearer #{api_key.token}" }
+
   path "/api/v1/categories" do
     get "List categories" do
       tags "Categories"
       produces "application/json"
+      security [ bearer_auth: [] ]
 
       response "200", "categories found" do
         schema type: :object,
@@ -21,6 +25,14 @@ RSpec.describe "Api::V1::Categories", type: :request do
 
         run_test!
       end
+
+      response "401", "unauthorized" do
+        schema "$ref" => "#/components/schemas/Error"
+
+        let(:Authorization) { "Bearer invalid" }
+
+        run_test!
+      end
     end
   end
 
@@ -30,6 +42,7 @@ RSpec.describe "Api::V1::Categories", type: :request do
     get "Show a category with recipes" do
       tags "Categories"
       produces "application/json"
+      security [ bearer_auth: [] ]
       parameter name: :page, in: :query, type: :integer, required: false
 
       response "200", "category found" do
@@ -53,6 +66,15 @@ RSpec.describe "Api::V1::Categories", type: :request do
         schema "$ref" => "#/components/schemas/Error"
 
         let(:id) { 0 }
+
+        run_test!
+      end
+
+      response "401", "unauthorized" do
+        schema "$ref" => "#/components/schemas/Error"
+
+        let(:Authorization) { "Bearer invalid" }
+        let(:id) { create(:category).id }
 
         run_test!
       end

--- a/spec/requests/api/v1/recipes_image_upload_spec.rb
+++ b/spec/requests/api/v1/recipes_image_upload_spec.rb
@@ -3,8 +3,8 @@
 require "rails_helper"
 
 RSpec.describe "Api::V1::Recipes Image Upload", type: :request do
-  let(:user) { create(:user, :with_api_token) }
-  let(:headers) { { "Authorization" => "Bearer #{user.api_token}", "Content-Type" => "application/json", "Accept" => "application/json" } }
+  let(:api_key) { create(:api_key) }
+  let(:headers) { { "Authorization" => "Bearer #{api_key.token}", "Content-Type" => "application/json", "Accept" => "application/json" } }
   let(:category) { create(:category) }
 
   # Small 1x1 red pixel JPEG in base64

--- a/spec/requests/api/v1/recipes_spec.rb
+++ b/spec/requests/api/v1/recipes_spec.rb
@@ -3,10 +3,14 @@
 require "swagger_helper"
 
 RSpec.describe "Api::V1::Recipes", type: :request do
+  let(:api_key) { create(:api_key) }
+  let(:Authorization) { "Bearer #{api_key.token}" }
+
   path "/api/v1/recipes" do
     get "List recipes" do
       tags "Recipes"
       produces "application/json"
+      security [ bearer_auth: [] ]
       parameter name: :page, in: :query, type: :integer, required: false, description: "Page number"
       parameter name: :limit, in: :query, type: :integer, required: false, description: "Items per page"
 
@@ -18,6 +22,14 @@ RSpec.describe "Api::V1::Recipes", type: :request do
                }
 
         before { create_list(:recipe, 3) }
+
+        run_test!
+      end
+
+      response "401", "unauthorized" do
+        schema "$ref" => "#/components/schemas/Error"
+
+        let(:Authorization) { "Bearer invalid" }
 
         run_test!
       end
@@ -58,8 +70,6 @@ RSpec.describe "Api::V1::Recipes", type: :request do
         }
       }
 
-      let(:user) { create(:user, :with_api_token) }
-      let(:Authorization) { "Bearer #{user.api_token}" }
       let(:category) { create(:category) }
 
       response "201", "recipe created" do
@@ -111,6 +121,7 @@ RSpec.describe "Api::V1::Recipes", type: :request do
     get "Search recipes" do
       tags "Recipes"
       produces "application/json"
+      security [ bearer_auth: [] ]
       parameter name: :query, in: :query, type: :string, required: true, description: "Search query"
       parameter name: :page, in: :query, type: :integer, required: false
 
@@ -135,6 +146,15 @@ RSpec.describe "Api::V1::Recipes", type: :request do
           expect(response.parsed_body.fetch("recipes")).to be_empty
         end
       end
+
+      response "401", "unauthorized" do
+        schema "$ref" => "#/components/schemas/Error"
+
+        let(:Authorization) { "Bearer invalid" }
+        let(:query) { "chicken" }
+
+        run_test!
+      end
     end
   end
 
@@ -144,6 +164,7 @@ RSpec.describe "Api::V1::Recipes", type: :request do
     get "Show a recipe" do
       tags "Recipes"
       produces "application/json"
+      security [ bearer_auth: [] ]
 
       response "200", "recipe found" do
         schema "$ref" => "#/components/schemas/Recipe"
@@ -157,6 +178,15 @@ RSpec.describe "Api::V1::Recipes", type: :request do
         schema "$ref" => "#/components/schemas/Error"
 
         let(:id) { 0 }
+
+        run_test!
+      end
+
+      response "401", "unauthorized" do
+        schema "$ref" => "#/components/schemas/Error"
+
+        let(:Authorization) { "Bearer invalid" }
+        let(:id) { create(:recipe).id }
 
         run_test!
       end
@@ -180,8 +210,6 @@ RSpec.describe "Api::V1::Recipes", type: :request do
         }
       }
 
-      let(:user) { create(:user, :with_api_token) }
-      let(:Authorization) { "Bearer #{user.api_token}" }
       let(:existing_recipe) { create(:recipe) }
       let(:id) { existing_recipe.id }
 
@@ -207,8 +235,6 @@ RSpec.describe "Api::V1::Recipes", type: :request do
       tags "Recipes"
       security [ bearer_auth: [] ]
 
-      let(:user) { create(:user, :with_api_token) }
-      let(:Authorization) { "Bearer #{user.api_token}" }
       let(:id) { create(:recipe).id }
 
       response "204", "recipe deleted" do

--- a/spec/requests/api_keys_spec.rb
+++ b/spec/requests/api_keys_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "ApiKeys", type: :request do
+  let(:user) { create(:user) }
+
+  describe "POST /api_keys" do
+    it "redirects to sign-in when logged out" do
+      post api_keys_path, params: { api_key: { name: "MCP server" } }
+
+      expect(response).to redirect_to(sign_in_path)
+      expect(ApiKey.count).to eq(0)
+    end
+
+    it "creates a key and shows the raw token exactly once" do
+      sign_in(user)
+
+      post api_keys_path, params: { api_key: { name: "MCP server" } }
+
+      expect(response).to redirect_to(account_path)
+      key = user.api_keys.sole
+      expect(key.name).to eq("MCP server")
+
+      follow_redirect!
+      expect(response.body).to match(/sb_[0-9a-f]{64}/)
+
+      get account_path
+      expect(response.body).not_to match(/sb_[0-9a-f]{64}/)
+      expect(response.body).to include(key.prefix)
+    end
+
+    it "rejects a blank name" do
+      sign_in(user)
+
+      post api_keys_path, params: { api_key: { name: "" } }
+
+      expect(response).to redirect_to(account_path)
+      expect(ApiKey.count).to eq(0)
+    end
+  end
+
+  describe "DELETE /api_keys/:id" do
+    let!(:api_key) { create(:api_key, user: user) }
+
+    it "redirects to sign-in when logged out" do
+      delete api_key_path(api_key)
+
+      expect(response).to redirect_to(sign_in_path)
+      expect(api_key.reload).to be_active
+    end
+
+    it "revokes the key without deleting it" do
+      sign_in(user)
+
+      delete api_key_path(api_key)
+
+      expect(response).to redirect_to(account_path)
+      expect(api_key.reload).not_to be_active
+      expect(ApiKey.exists?(api_key.id)).to be(true)
+    end
+
+    it "returns 404 for another user's key" do
+      other_key = create(:api_key)
+      sign_in(user)
+
+      delete api_key_path(other_key)
+
+      expect(response).to have_http_status(:not_found)
+      expect(other_key.reload).to be_active
+    end
+  end
+
+  describe "GET /account/export" do
+    it "includes key metadata but never tokens or digests" do
+      key = create(:api_key, user: user, name: "Export me")
+      sign_in(user)
+
+      get account_export_path
+
+      export = JSON.parse(response.body)
+      expect(export["api_keys"]).to contain_exactly(
+        a_hash_including("name" => "Export me", "prefix" => key.prefix)
+      )
+      expect(response.body).not_to include(key.token_digest)
+      expect(response.body).not_to match(/sb_[0-9a-f]{64}/)
+    end
+  end
+end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -16,15 +16,14 @@ RSpec.configure do |config|
 
           ## Authentication
 
-          Some endpoints require authentication via Bearer token. To get a token:
+          **All endpoints require authentication** via a Bearer API key.
 
-          ```ruby
-          # In Rails console (bin/rails console)
-          user = User.find_by(email: "your@email.com")
-          user.generate_api_token!
-          ```
+          Create a key on the [Account page](/account) (API Keys section): give it a
+          name, click **Create key**, and copy the `sb_...` token — it is shown
+          exactly once and cannot be retrieved again. Keys can be revoked from the
+          same page at any time.
 
-          Click the **Authorize** button above and enter your token (without "Bearer" prefix).
+          Click the **Authorize** button above and enter your key (without "Bearer" prefix).
         DESC
       },
       paths: {},

--- a/spec/system/api_keys_spec.rb
+++ b/spec/system/api_keys_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "API key management", type: :system do
+  let(:user) { create(:user) }
+
+  before { sign_in_as(user) }
+
+  it "creates a key, shows the token once, and hides it after reload" do
+    visit account_path
+
+    fill_in "Key name", with: "MCP server"
+    click_button "Create key"
+
+    expect(page).to have_content("Copy it now")
+    expect(page).to have_content(/sb_[0-9a-f]{64}/)
+    expect(page).to have_button("Copy")
+
+    visit account_path
+
+    expect(page).not_to have_content(/sb_[0-9a-f]{64}/)
+    expect(page).to have_content("MCP server")
+    expect(page).to have_content(user.api_keys.sole.prefix)
+    expect(page).to have_content("Last used Never")
+  end
+
+  it "revokes a key with confirmation and shows it struck-through" do
+    create(:api_key, user: user, name: "Old key")
+
+    visit account_path
+
+    accept_confirm do
+      click_link "Revoke"
+    end
+
+    expect(page).to have_content("Revoked")
+    expect(page).not_to have_link("Revoke")
+    expect(user.api_keys.sole).not_to be_active
+  end
+
+  it "never renders tokens for pre-existing keys" do
+    key = create(:api_key, user: user, name: "Existing")
+
+    visit account_path
+
+    expect(page).to have_content(key.prefix)
+    expect(page).not_to have_content(/sb_[0-9a-f]{64}/)
+  end
+end

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -8,15 +8,14 @@ info:
 
     ## Authentication
 
-    Some endpoints require authentication via Bearer token. To get a token:
+    **All endpoints require authentication** via a Bearer API key.
 
-    ```ruby
-    # In Rails console (bin/rails console)
-    user = User.find_by(email: "your@email.com")
-    user.generate_api_token!
-    ```
+    Create a key on the [Account page](/account) (API Keys section): give it a
+    name, click **Create key**, and copy the `sb_...` token — it is shown
+    exactly once and cannot be retrieved again. Keys can be revoked from the
+    same page at any time.
 
-    Click the **Authorize** button above and enter your token (without "Bearer" prefix).
+    Click the **Authorize** button above and enter your key (without "Bearer" prefix).
 paths:
   "/api/v1/baskets":
     get:
@@ -120,6 +119,8 @@ paths:
       summary: List categories
       tags:
       - Categories
+      security:
+      - bearer_auth: []
       responses:
         '200':
           description: categories found
@@ -132,6 +133,12 @@ paths:
                     type: array
                     items:
                       "$ref": "#/components/schemas/Category"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
   "/api/v1/categories/{id}":
     parameters:
     - name: id
@@ -143,6 +150,8 @@ paths:
       summary: Show a category with recipes
       tags:
       - Categories
+      security:
+      - bearer_auth: []
       parameters:
       - name: page
         in: query
@@ -173,11 +182,19 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/Error"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
   "/api/v1/recipes":
     get:
       summary: List recipes
       tags:
       - Recipes
+      security:
+      - bearer_auth: []
       parameters:
       - name: page
         in: query
@@ -205,6 +222,12 @@ paths:
                       "$ref": "#/components/schemas/Recipe"
                   pagination:
                     "$ref": "#/components/schemas/Pagination"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
     post:
       summary: Create a recipe
       tags:
@@ -279,6 +302,8 @@ paths:
       summary: Search recipes
       tags:
       - Recipes
+      security:
+      - bearer_auth: []
       parameters:
       - name: query
         in: query
@@ -293,7 +318,7 @@ paths:
           type: integer
       responses:
         '200':
-          description: search results
+          description: SQL metacharacters are treated literally
           content:
             application/json:
               schema:
@@ -305,6 +330,12 @@ paths:
                       "$ref": "#/components/schemas/Recipe"
                   pagination:
                     "$ref": "#/components/schemas/Pagination"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
   "/api/v1/recipes/{id}":
     parameters:
     - name: id
@@ -316,6 +347,8 @@ paths:
       summary: Show a recipe
       tags:
       - Recipes
+      security:
+      - bearer_auth: []
       responses:
         '200':
           description: recipe found
@@ -325,6 +358,12 @@ paths:
                 "$ref": "#/components/schemas/Recipe"
         '404':
           description: recipe not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '401':
+          description: unauthorized
           content:
             application/json:
               schema:


### PR DESCRIPTION
Closes #131, #132, #133, #134 (epic #135).

## Summary
- **ApiKey model** (#131): `api_keys` table storing SHA-256 digests only — raw `sb_...` token is exposed exactly once at creation and never retrievable again. Named, revocable (`revoked_at` soft delete), with throttled `last_used_at` tracking. A data migration backfills existing `users.api_token` values as a 'Legacy key' so current MCP configs keep working; the legacy column is dropped in a follow-up release.
- **API-wide auth** (#132): every `/api/v1` endpoint now requires a valid Bearer key — including recipe/category reads and search. 401 responses carry `WWW-Authenticate: Bearer`. Web session flows are untouched; `/up` and `/api-docs` stay public. OpenAPI docs regenerated with the global security scheme and 401 responses.
- **Account UI** (#133): `/account` gains an API Keys section — create a named key, see the token once in a highlighted panel with a copy button (Stimulus, CSP-safe), list keys with prefix/created/last-used, revoke with confirmation. Key metadata (never tokens) added to the GDPR export.
- **MCP + docs** (#134): `mcp-server` fails fast without `API_TOKEN` and surfaces 401s with an actionable message; both READMEs document the new /account flow and key lifecycle.

## Test plan
- [x] `bundle exec rspec` — model specs (digest-only persistence, one-time exposure, revocation, throttling, legacy backfill), rswag request specs (401 for missing/garbage/revoked keys on every endpoint), request + system specs for the account UI (token visible once, gone on reload, owner-scoped revoke) — 295 examples, 0 failures
- [x] `bundle exec rubocop` and `bundle exec brakeman -q --no-pager` clean
- [x] `swagger/v1/swagger.yaml` regenerated via `rails rswag:specs:swaggerize`
- [x] Manual: mint a key at `/account`, hit `GET /api/v1/recipes` with and without it, revoke, confirm immediate 401; run the MCP server end-to-end against the minted key

🤖 Generated with [Claude Code](https://claude.com/claude-code)