### PR TITLE
🖼️ Replace DuckDuckGo scraping with the Pexels API for recipe images

### DIFF
--- a/app/jobs/fetch_recipe_image_job.rb
+++ b/app/jobs/fetch_recipe_image_job.rb
@@ -4,6 +4,8 @@ class FetchRecipeImageJob < ApplicationJob
   queue_as :default
 
   ALLOWED_CONTENT_TYPES = %w[image/png image/jpeg image/webp image/gif].freeze
+  MAX_IMAGE_BYTES = 2_000_000
+  PEXELS_SEARCH_URL = "https://api.pexels.com/v1/search"
 
   def perform(recipe_id, search_query = nil)
     recipe = Recipe.find_by(id: recipe_id)
@@ -20,50 +22,64 @@ class FetchRecipeImageJob < ApplicationJob
   private
 
   def fetch_image(query)
-    search_query = URI.encode_www_form_component("#{query} recipe")
+    api_key = ENV["PEXELS_API_KEY"]
+    if api_key.blank?
+      Rails.logger.warn("FetchRecipeImageJob skipped: PEXELS_API_KEY is not set")
+      return nil
+    end
 
-    # Get DuckDuckGo vqd token
-    token_url = "https://duckduckgo.com/?q=#{search_query}&iax=images&ia=images"
-    token_response = fetch_with_timeout(token_url)
-    return nil unless token_response
+    image_url = search_pexels(query, api_key)
+    return nil unless image_url
 
-    vqd = token_response.body.match(/vqd=([^&"]+)/)&.[](1)
-    return nil unless vqd
+    download_image(image_url)
+  rescue StandardError => e
+    Rails.logger.warn("FetchRecipeImageJob error for #{query.inspect}: #{e.message}")
+    nil
+  end
 
-    # Search images
-    api_url = "https://duckduckgo.com/i.js?l=us-en&o=json&q=#{search_query}&vqd=#{vqd}&f=,,,,,&p=1"
-    api_response = fetch_with_timeout(api_url)
-    return nil unless api_response
+  def search_pexels(query, api_key)
+    search_term = URI.encode_www_form_component("#{query} recipe")
+    response = fetch_with_timeout("#{PEXELS_SEARCH_URL}?query=#{search_term}&per_page=5",
+                                  headers: { "Authorization" => api_key })
+    unless response
+      Rails.logger.warn("FetchRecipeImageJob got no usable response from Pexels for #{query.inspect}")
+      return nil
+    end
 
-    data = JSON.parse(api_response.body)
-    results = data["results"]
-    return nil if results.blank?
+    photos = JSON.parse(response.body)["photos"]
+    if photos.blank?
+      Rails.logger.warn("FetchRecipeImageJob found no Pexels photos for #{query.inspect}")
+      return nil
+    end
 
-    # Find reasonably sized image
-    result = results.find { |r| r["width"].to_i < 1200 && r["width"].to_i > 300 } || results.first
-    image_url = result["image"]
+    photos.first.dig("src", "large")
+  end
 
-    # Download image
-    image_response = fetch_with_timeout(image_url)
-    return nil unless image_response
-    return nil if image_response.body.bytesize > 2_000_000
+  def download_image(image_url)
+    response = fetch_with_timeout(image_url)
+    unless response
+      Rails.logger.warn("FetchRecipeImageJob failed to download image from #{image_url}")
+      return nil
+    end
 
-    content_type = image_response["Content-Type"].to_s.split(";", 2).first.to_s.strip.downcase
+    if response.body.bytesize > MAX_IMAGE_BYTES
+      Rails.logger.warn("FetchRecipeImageJob skipped oversized image (#{response.body.bytesize} bytes) from #{image_url}")
+      return nil
+    end
+
+    content_type = response["Content-Type"].to_s.split(";", 2).first.to_s.strip.downcase
     unless content_type.start_with?("image/") && content_type.in?(ALLOWED_CONTENT_TYPES)
       Rails.logger.warn("FetchRecipeImageJob skipped unsupported image Content-Type: #{content_type.presence || 'missing'}")
       return nil
     end
 
     {
-      data: image_response.body,
+      data: response.body,
       content_type: content_type
     }
-  rescue StandardError => e
-    Rails.logger.error("FetchRecipeImageJob error: #{e.message}")
-    nil
   end
 
-  def fetch_with_timeout(url, timeout: 10)
+  def fetch_with_timeout(url, timeout: 10, headers: {})
     uri = URI.parse(url)
     http = Net::HTTP.new(uri.host, uri.port)
     http.use_ssl = uri.scheme == "https"
@@ -72,6 +88,7 @@ class FetchRecipeImageJob < ApplicationJob
 
     request = Net::HTTP::Get.new(uri)
     request["User-Agent"] = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"
+    headers.each { |key, value| request[key] = value }
 
     response = http.request(request)
     response.is_a?(Net::HTTPSuccess) ? response : nil

--- a/spec/jobs/fetch_recipe_image_job_spec.rb
+++ b/spec/jobs/fetch_recipe_image_job_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe FetchRecipeImageJob do
   subject(:perform_job) { described_class.perform_now(recipe.id) }
 
   let(:recipe) { create(:recipe, title: "Toast") }
-  let(:token_response) { instance_double(Net::HTTPSuccess, body: 'vqd=token123&') }
   let(:search_response) do
-    instance_double(Net::HTTPSuccess, body: { results: [ { width: 600, image: "https://example.com/image" } ] }.to_json)
+    instance_double(Net::HTTPSuccess,
+                    body: { photos: [ { src: { large: "https://images.pexels.com/photo.jpg" } } ] }.to_json)
   end
 
   def image_response(content_type:, body: "image data")
@@ -18,12 +18,16 @@ RSpec.describe FetchRecipeImageJob do
   end
 
   before do
-    allow_any_instance_of(described_class).to receive(:fetch_with_timeout)
-      .and_return(token_response, search_response, downloaded_response)
+    allow(ENV).to receive(:[]).and_call_original
+    allow(ENV).to receive(:[]).with("PEXELS_API_KEY").and_return("test-key")
+    allow(Rails.logger).to receive(:warn)
   end
 
   context "with an allowed image response" do
-    let(:downloaded_response) { image_response(content_type: "image/png") }
+    before do
+      allow_any_instance_of(described_class).to receive(:fetch_with_timeout)
+        .and_return(search_response, image_response(content_type: "image/png"))
+    end
 
     it "attaches the downloaded image" do
       perform_job
@@ -31,25 +35,119 @@ RSpec.describe FetchRecipeImageJob do
       expect(recipe.reload.image).to be_attached
       expect(recipe.image.blob.content_type).to eq("image/png")
     end
+
+    it "searches Pexels with the API key and a recipe-suffixed query" do
+      expect_any_instance_of(described_class).to receive(:fetch_with_timeout)
+        .with("https://api.pexels.com/v1/search?query=Toast+recipe&per_page=5",
+              headers: { "Authorization" => "test-key" })
+        .and_return(search_response)
+      expect_any_instance_of(described_class).to receive(:fetch_with_timeout)
+        .with("https://images.pexels.com/photo.jpg")
+        .and_return(image_response(content_type: "image/jpeg"))
+
+      perform_job
+    end
   end
 
   context "with a non-image response" do
-    let(:downloaded_response) { image_response(content_type: "text/html") }
+    before do
+      allow_any_instance_of(described_class).to receive(:fetch_with_timeout)
+        .and_return(search_response, image_response(content_type: "text/html"))
+    end
 
-    it "does not attach the response" do
+    it "does not attach the response and logs why" do
       expect { perform_job }.not_to raise_error
 
       expect(recipe.reload.image).not_to be_attached
+      expect(Rails.logger).to have_received(:warn).with(/unsupported image Content-Type: text\/html/)
     end
   end
 
   context "with an unsupported image response" do
-    let(:downloaded_response) { image_response(content_type: "image/svg+xml") }
+    before do
+      allow_any_instance_of(described_class).to receive(:fetch_with_timeout)
+        .and_return(search_response, image_response(content_type: "image/svg+xml"))
+    end
 
     it "does not attach the response" do
       perform_job
 
       expect(recipe.reload.image).not_to be_attached
+    end
+  end
+
+  context "with an oversized image response" do
+    before do
+      allow_any_instance_of(described_class).to receive(:fetch_with_timeout)
+        .and_return(search_response, image_response(content_type: "image/jpeg", body: "x" * 2_000_001))
+    end
+
+    it "does not attach the response and logs why" do
+      perform_job
+
+      expect(recipe.reload.image).not_to be_attached
+      expect(Rails.logger).to have_received(:warn).with(/oversized image/)
+    end
+  end
+
+  context "when PEXELS_API_KEY is not set" do
+    before do
+      allow(ENV).to receive(:[]).with("PEXELS_API_KEY").and_return(nil)
+    end
+
+    it "makes no HTTP calls, attaches nothing, and logs a warning" do
+      expect_any_instance_of(described_class).not_to receive(:fetch_with_timeout)
+
+      perform_job
+
+      expect(recipe.reload.image).not_to be_attached
+      expect(Rails.logger).to have_received(:warn).with(/PEXELS_API_KEY is not set/)
+    end
+  end
+
+  context "when the Pexels search returns no usable response" do
+    before do
+      allow_any_instance_of(described_class).to receive(:fetch_with_timeout).and_return(nil)
+    end
+
+    it "does not attach anything and logs a warning" do
+      perform_job
+
+      expect(recipe.reload.image).not_to be_attached
+      expect(Rails.logger).to have_received(:warn).with(/no usable response from Pexels/)
+    end
+  end
+
+  context "when Pexels finds no photos" do
+    let(:search_response) { instance_double(Net::HTTPSuccess, body: { photos: [] }.to_json) }
+
+    before do
+      allow_any_instance_of(described_class).to receive(:fetch_with_timeout).and_return(search_response)
+    end
+
+    it "does not attach anything and logs a warning" do
+      perform_job
+
+      expect(recipe.reload.image).not_to be_attached
+      expect(Rails.logger).to have_received(:warn).with(/no Pexels photos/)
+    end
+  end
+
+  context "when the recipe already has an image" do
+    before do
+      recipe.image.attach(io: StringIO.new("existing"), filename: "existing.jpg", content_type: "image/jpeg")
+    end
+
+    it "makes no HTTP calls" do
+      expect_any_instance_of(described_class).not_to receive(:fetch_with_timeout)
+
+      perform_job
+    end
+  end
+
+  context "when the recipe no longer exists" do
+    it "does nothing" do
+      expect { described_class.perform_now(0) }.not_to raise_error
     end
   end
 end


### PR DESCRIPTION
Closes #137.

## Summary
- `FetchRecipeImageJob` now searches the [Pexels API](https://www.pexels.com/api/) (`Authorization` header, key from `PEXELS_API_KEY`) instead of scraping DuckDuckGo's internal `i.js` endpoint, which bot-blocks the production server's datacenter IP
- First result's `src.large` is downloaded through the existing pipeline — 2MB cap, content-type allowlist, and `attach_image` unchanged
- Missing `PEXELS_API_KEY` is a logged no-op, mirroring the previous optional behaviour
- **Silent failures eliminated**: every bail-out path (missing key, no/bad Pexels response, zero results, oversized or unsupported download) logs one greppable `warn` line, so a `finished` job that attached nothing now says why
- `fetch_with_timeout` gains a `headers:` option; behaviour otherwise unchanged

## Test plan
- [x] Job spec rewritten for the Pexels flow: happy path (incl. exact search URL + auth header), missing key (no HTTP calls), no response, zero photos, oversized, non-image and unsupported content types, already-attached and deleted-recipe no-ops — 10 examples
- [x] Full suite 302 examples green; RuboCop and Brakeman clean
- [ ] After merge: set `PEXELS_API_KEY` in Hatchbox (key from pexels.com/api), deploy, then backfill imageless recipes from the production console:
```ruby
Recipe.left_joins(:image_attachment).where(active_storage_attachments: { id: nil }).find_each { |r| FetchRecipeImageJob.perform_later(r.id) }
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)