### PR TITLE
📅 Weekly meal plans: Mon–Sun board, draft→accepted, archived history

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,10 @@ A recipe discovery and meal planning application built with Ruby on Rails. Brows
 ## Features
 
 - **Recipe Browsing** - Browse recipes with search by title and ingredients
-- **Categories** - Organized by meal type (Breakfast, Main Course, Dessert)
-- **Meal Planning** - Add recipes to your basket to plan meals
-- **Smart Shopping Lists** - Automatically aggregates ingredients across selected recipes
+- **Categories** - Organized by meal type (Breakfast, Lunch, Dinner, Desserts)
+- **Weekly Meal Plans** - Plan Monday-Sunday, one plan per week, with an auto-fill option that picks a breakfast, lunch and dinner for every day. Draft plans are editable; accept a plan to lock it (reopen until the week ends); past weeks archive automatically as read-only history
+- **Saved Recipes** - Bookmark recipes into a pool that feeds the meal plan picker
+- **Smart Shopping Lists** - Automatically aggregates ingredients across a plan's recipes, with print and copy
 - **Rich Content** - Full recipe details with images, prep time, servings, and nutrition info
 
 ## Tech Stack
@@ -166,6 +167,14 @@ Interactive API documentation available at [/api-docs](/api-docs) (Swagger UI).
 | GET | `/api/v1/baskets` | Yes | User's basket |
 | POST | `/api/v1/baskets` | Yes | Add recipe to basket |
 | DELETE | `/api/v1/baskets/:id` | Yes | Remove from basket |
+| GET | `/api/v1/meal_plans` | Yes | List weekly meal plans (`?filter=active\|archived`) |
+| POST | `/api/v1/meal_plans` | Yes | Plan a week (`auto_fill: true` picks a breakfast, lunch and dinner per day) |
+| GET | `/api/v1/meal_plans/:id` | Yes | A plan's Monday-Sunday grid |
+| POST | `/api/v1/meal_plans/:id/accept` | Yes | Lock a plan |
+| POST | `/api/v1/meal_plans/:id/reopen` | Yes | Unlock (until the week ends) |
+| GET | `/api/v1/meal_plans/:id/shopping_list` | Yes | Aggregated ingredients for the week |
+| POST | `/api/v1/meal_plans/:id/entries` | Yes | Add a recipe to a day |
+| DELETE | `/api/v1/meal_plans/:id/entries/:id` | Yes | Remove a recipe from a day |
 
 ### Authentication
 

--- a/app/controllers/api/v1/meal_plan_entries_controller.rb
+++ b/app/controllers/api/v1/meal_plan_entries_controller.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class MealPlanEntriesController < BaseController
+      before_action :set_meal_plan
+
+      def create
+        day_index = MealPlanEntry.day_index(params.dig(:entry, :day))
+        if day_index.nil?
+          return render json: { errors: [ "day is invalid" ] }, status: :unprocessable_entity
+        end
+
+        entry = @meal_plan.meal_plan_entries.new(
+          recipe_id: params.dig(:entry, :recipe_id),
+          day_of_week: day_index
+        )
+        entry.save!
+
+        render json: {
+          entry_id: entry.id,
+          day: entry.day_name,
+          recipe: {
+            id: entry.recipe.id,
+            title: entry.recipe.title,
+            description: entry.recipe.description,
+            prep_time: entry.recipe.prep_time,
+            serves: entry.recipe.serves
+          }
+        }, status: :created
+      end
+
+      def destroy
+        entry = @meal_plan.meal_plan_entries.find(params[:id])
+
+        if entry.destroy
+          head :no_content
+        else
+          render json: { errors: entry.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      private
+
+      def set_meal_plan
+        @meal_plan = current_user.meal_plans.find(params[:meal_plan_id])
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/meal_plans_controller.rb
+++ b/app/controllers/api/v1/meal_plans_controller.rb
@@ -26,6 +26,7 @@ module Api
         meal_plan = current_user.meal_plans.new(week_start_date: week_start)
 
         if meal_plan.save
+          meal_plan.auto_fill! if ActiveModel::Type::Boolean.new.cast(params.dig(:meal_plan, :auto_fill))
           render json: plan_json(meal_plan), status: :created
         elsif (existing = duplicate_week_plan(meal_plan))
           render json: {

--- a/app/controllers/api/v1/meal_plans_controller.rb
+++ b/app/controllers/api/v1/meal_plans_controller.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class MealPlansController < BaseController
+      before_action :set_meal_plan, only: [ :show, :destroy, :accept, :reopen, :shopping_list ]
+
+      def index
+        plans = current_user.meal_plans.ordered
+        plans = plans.active if params[:filter] == "active"
+        plans = plans.archived if params[:filter] == "archived"
+
+        @pagy, plans = pagy(plans)
+        render json: {
+          meal_plans: plans.map { |plan| plan_summary(plan) },
+          meta: pagy_metadata(@pagy)
+        }
+      end
+
+      def show
+        render json: plan_json(@meal_plan)
+      end
+
+      def create
+        week_start = params.dig(:meal_plan, :week_start_date).presence || Date.current
+        meal_plan = current_user.meal_plans.new(week_start_date: week_start)
+
+        if meal_plan.save
+          render json: plan_json(meal_plan), status: :created
+        elsif (existing = duplicate_week_plan(meal_plan))
+          render json: {
+            error: "A meal plan already exists for this week",
+            meal_plan: plan_json(existing)
+          }, status: :conflict
+        else
+          render json: { errors: meal_plan.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      def destroy
+        if @meal_plan.editable?
+          @meal_plan.destroy
+          head :no_content
+        else
+          render json: { errors: [ "Meal plan is locked" ] }, status: :unprocessable_entity
+        end
+      end
+
+      def accept
+        if @meal_plan.accept!
+          render json: plan_json(@meal_plan)
+        else
+          render json: { errors: [ "Meal plan cannot be accepted" ] }, status: :unprocessable_entity
+        end
+      end
+
+      def reopen
+        if @meal_plan.reopen!
+          render json: plan_json(@meal_plan)
+        else
+          render json: { errors: [ "Meal plan cannot be reopened" ] }, status: :unprocessable_entity
+        end
+      end
+
+      def shopping_list
+        render json: {
+          week_start_date: @meal_plan.week_start_date,
+          ingredients: @meal_plan.aggregated_ingredients
+        }
+      end
+
+      private
+
+      def set_meal_plan
+        @meal_plan = current_user.meal_plans.find(params[:id])
+      end
+
+      def duplicate_week_plan(meal_plan)
+        return nil unless meal_plan.errors.added?(:week_start_date, "already has a plan for this week")
+
+        current_user.meal_plans.find_by(week_start_date: meal_plan.week_start_date)
+      end
+
+      def plan_summary(plan)
+        {
+          id: plan.id,
+          week_start_date: plan.week_start_date,
+          week_end_date: plan.week_end_date,
+          status: plan.status,
+          archived: plan.archived?,
+          editable: plan.editable?,
+          entry_count: plan.meal_plan_entries.size
+        }
+      end
+
+      def plan_json(plan)
+        entries = plan.meal_plan_entries.includes(:recipe)
+        days = MealPlanEntry::DAYS.index_with { [] }
+        entries.each do |entry|
+          days[entry.day_name] << entry_json(entry)
+        end
+
+        plan_summary(plan).except(:entry_count).merge(days: days)
+      end
+
+      def entry_json(entry)
+        {
+          entry_id: entry.id,
+          recipe: {
+            id: entry.recipe.id,
+            title: entry.recipe.title,
+            description: entry.recipe.description,
+            prep_time: entry.recipe.prep_time,
+            serves: entry.recipe.serves
+          }
+        }
+      end
+    end
+  end
+end

--- a/app/controllers/meal_plan_entries_controller.rb
+++ b/app/controllers/meal_plan_entries_controller.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+class MealPlanEntriesController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_meal_plan
+
+  def create
+    day_index = MealPlanEntry.day_index(params.dig(:entry, :day))
+    entry = @meal_plan.meal_plan_entries.new(recipe_id: params.dig(:entry, :recipe_id), day_of_week: day_index)
+
+    if day_index && entry.save
+      respond_with_day_update(entry.day_name)
+    else
+      redirect_to @meal_plan, alert: entry.errors.full_messages.to_sentence.presence || "Could not add that meal"
+    end
+  end
+
+  def destroy
+    entry = @meal_plan.meal_plan_entries.find(params[:id])
+
+    if entry.destroy
+      respond_with_day_update(entry.day_name)
+    else
+      redirect_to @meal_plan, alert: entry.errors.full_messages.to_sentence
+    end
+  end
+
+  private
+
+  def set_meal_plan
+    @meal_plan = current_user.meal_plans.find(params[:meal_plan_id])
+  end
+
+  def respond_with_day_update(day_name)
+    respond_to do |format|
+      format.turbo_stream do
+        entries = @meal_plan.meal_plan_entries.includes(recipe: { image_attachment: :blob }).group_by(&:day_of_week)
+        day_index = MealPlanEntry.day_index(day_name)
+
+        render turbo_stream: [
+          turbo_stream.replace(
+            "day-#{day_name}",
+            partial: "meal_plans/day_cell",
+            locals: { meal_plan: @meal_plan, day_index: day_index, entries: entries[day_index] || [] }
+          ),
+          turbo_stream.replace(
+            "shopping-list",
+            partial: "meal_plans/shopping_list",
+            locals: { meal_plan: @meal_plan }
+          )
+        ]
+      end
+      format.html { redirect_to @meal_plan }
+    end
+  end
+end

--- a/app/controllers/meal_plans_controller.rb
+++ b/app/controllers/meal_plans_controller.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+class MealPlansController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_meal_plan, only: [ :show, :destroy, :accept, :reopen ]
+
+  def index
+    @current_plan = current_user.meal_plans.find_by(week_start_date: MealPlan.normalize_week_start(Date.current))
+    @upcoming_plans = current_user.meal_plans.active.ordered.where.not(week_start_date: MealPlan.normalize_week_start(Date.current))
+    @archived_count = current_user.meal_plans.archived.count
+  end
+
+  def show
+    @entries_by_day = @meal_plan.meal_plan_entries.includes(recipe: { image_attachment: :blob }).group_by(&:day_of_week)
+    return unless @meal_plan.editable?
+
+    @saved_recipes = current_user.baskets.includes(recipe: { image_attachment: :blob }).map(&:recipe)
+    @all_recipes = Recipe.includes(image_attachment: :blob).order(:title) - @saved_recipes
+  end
+
+  def create
+    week_start = parse_week(params.dig(:meal_plan, :week_start_date))
+    meal_plan = current_user.meal_plans.new(week_start_date: week_start)
+
+    if meal_plan.save
+      redirect_to meal_plan, notice: "Meal plan created — start adding meals!"
+    elsif (existing = current_user.meal_plans.find_by(week_start_date: MealPlan.normalize_week_start(week_start)))
+      redirect_to existing, notice: "You already have a plan for that week"
+    else
+      redirect_to meal_plans_path, alert: meal_plan.errors.full_messages.to_sentence
+    end
+  end
+
+  def destroy
+    if @meal_plan.editable?
+      @meal_plan.destroy
+      redirect_to meal_plans_path, notice: "Meal plan deleted"
+    else
+      redirect_to @meal_plan, alert: "This plan is locked and cannot be deleted"
+    end
+  end
+
+  def accept
+    if @meal_plan.accept!
+      redirect_to @meal_plan, notice: "Plan accepted — it is now locked"
+    else
+      redirect_to @meal_plan, alert: "This plan cannot be accepted"
+    end
+  end
+
+  def reopen
+    if @meal_plan.reopen!
+      redirect_to @meal_plan, notice: "Plan reopened for editing"
+    else
+      redirect_to @meal_plan, alert: "This plan cannot be reopened"
+    end
+  end
+
+  def archive
+    @meal_plans = current_user.meal_plans.archived.ordered
+  end
+
+  private
+
+  def set_meal_plan
+    @meal_plan = current_user.meal_plans.find(params[:id])
+  end
+
+  def parse_week(raw)
+    raw.present? ? Date.parse(raw.to_s) : Date.current
+  rescue ArgumentError
+    Date.current
+  end
+end

--- a/app/controllers/meal_plans_controller.rb
+++ b/app/controllers/meal_plans_controller.rb
@@ -2,7 +2,7 @@
 
 class MealPlansController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_meal_plan, only: [ :show, :destroy, :accept, :reopen ]
+  before_action :set_meal_plan, only: [ :show, :destroy, :accept, :reopen, :auto_fill ]
 
   def index
     @current_plan = current_user.meal_plans.find_by(week_start_date: MealPlan.normalize_week_start(Date.current))
@@ -23,7 +23,12 @@ class MealPlansController < ApplicationController
     meal_plan = current_user.meal_plans.new(week_start_date: week_start)
 
     if meal_plan.save
-      redirect_to meal_plan, notice: "Meal plan created — start adding meals!"
+      if params.dig(:meal_plan, :auto_fill) != "0"
+        meal_plan.auto_fill!
+        redirect_to meal_plan, notice: "Meal plan created with a week of meals picked for you — swap anything you fancy"
+      else
+        redirect_to meal_plan, notice: "Meal plan created — start adding meals!"
+      end
     elsif (existing = current_user.meal_plans.find_by(week_start_date: MealPlan.normalize_week_start(week_start)))
       redirect_to existing, notice: "You already have a plan for that week"
     else
@@ -53,6 +58,14 @@ class MealPlansController < ApplicationController
       redirect_to @meal_plan, notice: "Plan reopened for editing"
     else
       redirect_to @meal_plan, alert: "This plan cannot be reopened"
+    end
+  end
+
+  def auto_fill
+    if @meal_plan.auto_fill!
+      redirect_to @meal_plan, notice: "Week filled with a breakfast, lunch and dinner per day"
+    else
+      redirect_to @meal_plan, alert: "This plan cannot be auto-filled"
     end
   end
 

--- a/app/controllers/meals_controller.rb
+++ b/app/controllers/meals_controller.rb
@@ -11,17 +11,17 @@ class MealsController < ApplicationController
   def destroy
     basket = find_basket
     basket&.destroy
-    redirect_to meal_plan_path, notice: "Recipe removed from your meal plan!"
+    redirect_to meals_path, notice: "Recipe removed from your saved recipes!"
   end
 
   def toggle
     basket = find_basket
     if basket
       basket.destroy
-      flash_message = "Recipe removed from your meal plan!"
+      flash_message = "Recipe removed from your saved recipes!"
     else
       current_user.baskets.create(recipe: @recipe)
-      flash_message = "Recipe added to your meal plan!"
+      flash_message = "Recipe saved!"
     end
 
     redirect_back fallback_location: recipes_path, notice: flash_message

--- a/app/helpers/meal_plans_helper.rb
+++ b/app/helpers/meal_plans_helper.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module MealPlansHelper
+  # Orders a day's entries breakfast -> lunch -> dinner -> everything else.
+  def sorted_day_entries(entries)
+    entries.sort_by { |entry| [ meal_slot_rank(entry.recipe), entry.recipe.title ] }
+  end
+
+  def meal_slot_rank(recipe)
+    MealPlan::MEAL_SLOTS.values.index { |names| names.include?(recipe.category&.name) } || MealPlan::MEAL_SLOTS.size
+  end
+end

--- a/app/javascript/controllers/meal_picker_controller.js
+++ b/app/javascript/controllers/meal_picker_controller.js
@@ -1,0 +1,28 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Drives the "add a meal" dialog on the meal plan board: opens it primed
+// with the day whose + button was clicked, filters the recipe list, and
+// closes after a successful Turbo submission.
+export default class extends Controller {
+  static targets = ["dialog", "dayField", "dayLabel", "search", "item"]
+
+  open(event) {
+    const day = event.currentTarget.dataset.day
+    this.dayFieldTarget.value = day
+    this.dayLabelTarget.textContent = day.charAt(0).toUpperCase() + day.slice(1)
+    this.searchTarget.value = ""
+    this.filter()
+    this.dialogTarget.showModal()
+  }
+
+  close() {
+    if (this.dialogTarget.open) this.dialogTarget.close()
+  }
+
+  filter() {
+    const query = this.searchTarget.value.trim().toLowerCase()
+    this.itemTargets.forEach(item => {
+      item.hidden = query !== "" && !item.dataset.name.includes(query)
+    })
+  }
+}

--- a/app/models/meal_plan.rb
+++ b/app/models/meal_plan.rb
@@ -1,6 +1,13 @@
 # frozen_string_literal: true
 
 class MealPlan < ApplicationRecord
+  # Slot order also drives display ordering within a day.
+  MEAL_SLOTS = {
+    "breakfast" => [ "Breakfast" ],
+    "lunch" => [ "Lunch" ],
+    "dinner" => [ "Dinner", "Main Course" ]
+  }.freeze
+
   belongs_to :user
   has_many :meal_plan_entries, dependent: :destroy
   has_many :recipes, through: :meal_plan_entries
@@ -52,6 +59,27 @@ class MealPlan < ApplicationRecord
     return false unless accepted? && !archived?
 
     update!(status: :draft)
+    true
+  end
+
+  # Fills the week with one breakfast, one lunch and one dinner per day,
+  # drawn from recipes whose category matches each slot. Recipes are spread
+  # across the week (no repeats until a slot's pool is exhausted); slots with
+  # no matching recipes are skipped. Existing entries are left untouched —
+  # a clash with one is simply skipped.
+  def auto_fill!
+    return false unless editable?
+
+    transaction do
+      MEAL_SLOTS.each_value do |category_names|
+        pool = Recipe.joins(:category).where(categories: { name: category_names }).to_a.shuffle
+        next if pool.empty?
+
+        7.times do |day|
+          meal_plan_entries.create(recipe: pool[day % pool.size], day_of_week: day)
+        end
+      end
+    end
     true
   end
 

--- a/app/models/meal_plan.rb
+++ b/app/models/meal_plan.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+class MealPlan < ApplicationRecord
+  belongs_to :user
+  has_many :meal_plan_entries, dependent: :destroy
+  has_many :recipes, through: :meal_plan_entries
+
+  enum :status, { draft: "draft", accepted: "accepted" }, default: :draft
+
+  before_validation :normalize_week_start_date
+
+  validates :week_start_date, presence: true
+  validates :week_start_date, uniqueness: { scope: :user_id, message: "already has a plan for this week" }
+  validate :week_not_in_the_past, on: :create
+
+  scope :archived, -> { where("week_start_date < ?", Date.current.beginning_of_week(:monday)) }
+  scope :active, -> { where("week_start_date >= ?", Date.current.beginning_of_week(:monday)) }
+  scope :ordered, -> { order(week_start_date: :desc) }
+
+  def self.normalize_week_start(date)
+    date.to_date.beginning_of_week(:monday)
+  end
+
+  def week_end_date
+    week_start_date + 6.days
+  end
+
+  def archived?
+    week_end_date < Date.current
+  end
+
+  def current_week?
+    week_start_date == Date.current.beginning_of_week(:monday)
+  end
+
+  def editable?
+    draft? && !archived?
+  end
+
+  def locked?
+    !editable?
+  end
+
+  def accept!
+    return false unless draft? && !archived?
+
+    update!(status: :accepted)
+    true
+  end
+
+  def reopen!
+    return false unless accepted? && !archived?
+
+    update!(status: :draft)
+    true
+  end
+
+  def aggregated_ingredients
+    db_adapter = ActiveRecord::Base.connection.adapter_name.downcase
+
+    if db_adapter.include?("sqlite")
+      recipes.joins("JOIN json_each(recipes.ingredients) AS ingredient")
+             .select("ingredient.value ->> '$.name' AS name,
+                      SUM(CAST(ingredient.value ->> '$.quantity' AS NUMERIC)) AS total_quantity,
+                      ingredient.value ->> '$.unit' AS unit")
+             .group("name, unit")
+             .map { |record| { name: record.name, quantity: record.total_quantity.to_f, unit: record.unit } }
+    else
+      recipes.joins("CROSS JOIN LATERAL jsonb_array_elements(recipes.ingredients::jsonb) AS ingredient")
+             .select("ingredient->>'name' AS name,
+                      SUM((ingredient->>'quantity')::NUMERIC) AS total_quantity,
+                      ingredient->>'unit' AS unit")
+             .group("ingredient->>'name', ingredient->>'unit'")
+             .map { |record| { name: record.name, quantity: record.total_quantity.to_f, unit: record.unit } }
+    end
+  end
+
+  private
+
+  def normalize_week_start_date
+    self.week_start_date = self.class.normalize_week_start(week_start_date) if week_start_date.present?
+  end
+
+  def week_not_in_the_past
+    return if week_start_date.blank?
+
+    if week_start_date < Date.current.beginning_of_week(:monday)
+      errors.add(:week_start_date, "cannot be in a past week")
+    end
+  end
+end

--- a/app/models/meal_plan_entry.rb
+++ b/app/models/meal_plan_entry.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class MealPlanEntry < ApplicationRecord
+  DAYS = %w[monday tuesday wednesday thursday friday saturday sunday].freeze
+
+  belongs_to :meal_plan
+  belongs_to :recipe
+
+  validates :day_of_week, inclusion: { in: 0..6 }
+  validates :recipe_id, uniqueness: { scope: [ :meal_plan_id, :day_of_week ], message: "is already planned for that day" }
+  validate :meal_plan_editable, on: :create
+
+  before_destroy :ensure_meal_plan_editable
+
+  def self.day_index(name)
+    DAYS.index(name.to_s.downcase)
+  end
+
+  def day_name
+    DAYS[day_of_week]
+  end
+
+  private
+
+  def meal_plan_editable
+    errors.add(:base, "meal plan is not editable") if meal_plan && !meal_plan.editable?
+  end
+
+  def ensure_meal_plan_editable
+    return if meal_plan.editable?
+
+    errors.add(:base, "meal plan is not editable")
+    throw :abort
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,7 @@ class User < ApplicationRecord
   has_many :baskets, dependent: :destroy
   has_many :recipes, through: :baskets
   has_many :api_keys, dependent: :destroy
+  has_many :meal_plans, dependent: :destroy
 
   validates :email, presence: true, uniqueness: true
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -55,14 +55,22 @@
     <div class="flex flex-1 justify-end">
     <div class="flex items-center gap-x-4">
       <% if user_signed_in? %>
-        <%# Meal plan link - always visible %>
-        <%= link_to meal_plan_path, class: "flex items-center gap-x-1 text-gray-500 hover:text-gray-700" do %>
+        <%# Weekly meal plan link - always visible %>
+        <%= link_to meal_plans_path, class: "flex items-center gap-x-1 text-gray-500 hover:text-gray-700" do %>
           <div class="relative">
             <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 3h2l.4 2M7 13h10l4-8H5.4M7 13L5.4 5M7 13l-2.293 2.293c-.63.63-.184 1.707.707 1.707H17m0 0a2 2 0 100 4 2 2 0 000-4zm-8 2a2 2 0 11-4 0 2 2 0 014 0z" />
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5" />
             </svg>
           </div>
-          <span class="text-sm font-medium"><%= pluralize(current_user.baskets.count, 'Meal') %></span>
+          <span class="text-sm font-medium">Meal Plan</span>
+        <% end %>
+
+        <%# Saved recipes link %>
+        <%= link_to meals_path, class: "flex items-center gap-x-1 text-gray-500 hover:text-gray-700" do %>
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.593 3.322c1.1.128 1.907 1.077 1.907 2.185V21L12 17.25 4.5 21V5.507c0-1.108.806-2.057 1.907-2.185a48.507 48.507 0 0111.186 0z" />
+          </svg>
+          <span class="text-sm font-medium"><%= pluralize(current_user.baskets.count, 'Saved Recipe') %></span>
         <% end %>
 
         <%# User dropdown menu %>

--- a/app/views/meal_plans/_day_cell.html.erb
+++ b/app/views/meal_plans/_day_cell.html.erb
@@ -1,0 +1,51 @@
+<% day_name = MealPlanEntry::DAYS[day_index] %>
+<% day_date = meal_plan.week_start_date + day_index %>
+<% is_today = day_date == Date.current %>
+<div id="day-<%= day_name %>"
+     class="flex flex-col rounded-lg border <%= is_today ? "border-indigo-300 ring-1 ring-indigo-200 bg-indigo-50/40" : "border-gray-200 bg-white" %> p-3">
+  <div class="flex items-baseline justify-between">
+    <h3 class="text-sm font-semibold <%= is_today ? "text-indigo-700" : "text-gray-900" %>"><%= day_name.capitalize %></h3>
+    <span class="text-xs <%= is_today ? "text-indigo-500" : "text-gray-400" %>"><%= day_date.strftime("%-d %b") %></span>
+  </div>
+
+  <div class="mt-2 flex flex-1 flex-col gap-2">
+    <% entries.each do |entry| %>
+      <div class="group relative overflow-hidden rounded-md border border-gray-100 bg-white shadow-sm">
+        <% if entry.recipe.image.attached? %>
+          <%= image_tag entry.recipe.image, class: "h-16 w-full object-cover", alt: entry.recipe.title %>
+        <% else %>
+          <div class="h-8 w-full bg-gray-100"></div>
+        <% end %>
+        <div class="flex items-start justify-between gap-x-1 p-2">
+          <%= link_to entry.recipe.title, recipe_path(entry.recipe),
+              class: "text-xs font-medium leading-snug text-gray-900 hover:text-indigo-600" %>
+          <% if meal_plan.editable? %>
+            <%= button_to meal_plan_entry_path(meal_plan, entry), method: :delete,
+                class: "shrink-0 rounded p-0.5 text-gray-300 hover:bg-red-50 hover:text-red-500",
+                title: "Remove #{entry.recipe.title}",
+                form: { data: { turbo_confirm: "Remove #{entry.recipe.title} from #{day_name.capitalize}?" } } do %>
+              <svg class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+              </svg>
+              <span class="sr-only">Remove</span>
+            <% end %>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
+
+    <% if meal_plan.editable? %>
+      <button type="button"
+              data-action="meal-picker#open"
+              data-day="<%= day_name %>"
+              class="mt-auto flex items-center justify-center gap-x-1 rounded-md border border-dashed border-gray-300 px-2 py-2 text-xs font-medium text-gray-500 hover:border-indigo-400 hover:text-indigo-600">
+        <svg class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
+        </svg>
+        Add
+      </button>
+    <% elsif entries.empty? %>
+      <p class="text-xs italic text-gray-400">Nothing planned</p>
+    <% end %>
+  </div>
+</div>

--- a/app/views/meal_plans/_day_cell.html.erb
+++ b/app/views/meal_plans/_day_cell.html.erb
@@ -9,7 +9,7 @@
   </div>
 
   <div class="mt-2 flex flex-1 flex-col gap-2">
-    <% entries.each do |entry| %>
+    <% sorted_day_entries(entries).each do |entry| %>
       <div class="group relative overflow-hidden rounded-md border border-gray-100 bg-white shadow-sm">
         <% if entry.recipe.image.attached? %>
           <%= image_tag entry.recipe.image, class: "h-16 w-full object-cover", alt: entry.recipe.title %>

--- a/app/views/meal_plans/_flash.html.erb
+++ b/app/views/meal_plans/_flash.html.erb
@@ -1,0 +1,6 @@
+<% if notice.present? %>
+  <div class="mb-6 rounded-md bg-green-50 px-4 py-3 text-sm font-medium text-green-700 ring-1 ring-inset ring-green-600/20"><%= notice %></div>
+<% end %>
+<% if alert.present? %>
+  <div class="mb-6 rounded-md bg-red-50 px-4 py-3 text-sm font-medium text-red-600 ring-1 ring-inset ring-red-400"><%= alert %></div>
+<% end %>

--- a/app/views/meal_plans/_picker.html.erb
+++ b/app/views/meal_plans/_picker.html.erb
@@ -1,0 +1,52 @@
+<dialog data-meal-picker-target="dialog"
+        class="w-full max-w-lg rounded-xl p-0 shadow-xl backdrop:bg-gray-900/50">
+  <div class="flex max-h-[80vh] flex-col">
+    <div class="flex items-center justify-between border-b border-gray-100 px-6 py-4">
+      <h3 class="text-base font-semibold text-gray-900">
+        Add to <span data-meal-picker-target="dayLabel">Monday</span>
+      </h3>
+      <button type="button" data-action="meal-picker#close" class="rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600">
+        <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+        </svg>
+        <span class="sr-only">Close</span>
+      </button>
+    </div>
+
+    <div class="border-b border-gray-100 px-6 py-3">
+      <input type="search" placeholder="Search recipes&hellip;"
+             data-meal-picker-target="search"
+             data-action="input->meal-picker#filter"
+             class="block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm placeholder:text-gray-400">
+    </div>
+
+    <%= form_with url: meal_plan_entries_path(@meal_plan), id: "add-meal-form",
+        class: "overflow-y-auto px-2 py-2",
+        data: { action: "turbo:submit-end->meal-picker#close" } do |form| %>
+      <%= form.hidden_field :day, name: "entry[day]", value: "monday", data: { meal_picker_target: "dayField" } %>
+
+      <% { "Saved recipes" => @saved_recipes, "All recipes" => @all_recipes }.each do |label, recipes| %>
+        <% next if recipes.blank? %>
+        <p class="px-4 pb-1 pt-3 text-xs font-semibold uppercase tracking-wide text-gray-400"><%= label %></p>
+        <ul>
+          <% recipes.each do |recipe| %>
+            <li data-meal-picker-target="item" data-name="<%= recipe.title.downcase %>">
+              <button type="submit" name="entry[recipe_id]" value="<%= recipe.id %>"
+                      class="flex w-full items-center gap-x-3 rounded-lg px-4 py-2 text-left hover:bg-indigo-50">
+                <% if recipe.image.attached? %>
+                  <%= image_tag recipe.image, class: "h-9 w-9 rounded-md object-cover", alt: "" %>
+                <% else %>
+                  <div class="h-9 w-9 rounded-md bg-gray-100"></div>
+                <% end %>
+                <span class="min-w-0">
+                  <span class="block truncate text-sm font-medium text-gray-900"><%= recipe.title %></span>
+                  <span class="block text-xs text-gray-500">Serves <%= recipe.serves %><%= " · #{recipe.prep_time}" if recipe.prep_time.present? %></span>
+                </span>
+              </button>
+            </li>
+          <% end %>
+        </ul>
+      <% end %>
+    <% end %>
+  </div>
+</dialog>

--- a/app/views/meal_plans/_shopping_list.html.erb
+++ b/app/views/meal_plans/_shopping_list.html.erb
@@ -1,0 +1,28 @@
+<div id="shopping-list" class="mt-12 print:mt-8" data-controller="clipboard">
+  <div class="flex items-center justify-between">
+    <h2 class="text-xl font-semibold text-gray-900">Shopping List</h2>
+    <% ingredients = meal_plan.aggregated_ingredients %>
+    <% if ingredients.any? %>
+      <button data-action="clipboard#copy"
+              class="inline-flex items-center gap-x-1.5 rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 print:hidden">
+        <svg data-clipboard-target="icon" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M15.666 3.888A2.25 2.25 0 0013.5 2.25h-3c-1.03 0-1.9.693-2.166 1.638m7.332 0c.055.194.084.4.084.612v0a.75.75 0 01-.75.75H9a.75.75 0 01-.75-.75v0c0-.212.03-.418.084-.612m7.332 0c.646.049 1.288.11 1.927.184 1.1.128 1.907 1.077 1.907 2.185V19.5a2.25 2.25 0 01-2.25 2.25H6.75A2.25 2.25 0 014.5 19.5V6.257c0-1.108.806-2.057 1.907-2.185a48.208 48.208 0 011.927-.184" />
+        </svg>
+        <span data-clipboard-target="text">Copy</span>
+      </button>
+    <% end %>
+  </div>
+
+  <% if ingredients.any? %>
+    <ul data-clipboard-target="content" class="mt-4 divide-y divide-gray-100 rounded-xl border border-gray-200 bg-white shadow-sm">
+      <% ingredients.each do |ingredient| %>
+        <li class="flex items-center justify-between px-4 py-2.5 text-sm">
+          <span class="text-gray-900"><%= ingredient[:name].capitalize %></span>
+          <span class="text-gray-500"><%= ingredient[:quantity] %> <%= ingredient[:unit] %></span>
+        </li>
+      <% end %>
+    </ul>
+  <% else %>
+    <p class="mt-4 text-sm text-gray-500">Add meals to the plan and their ingredients will appear here.</p>
+  <% end %>
+</div>

--- a/app/views/meal_plans/_status_pill.html.erb
+++ b/app/views/meal_plans/_status_pill.html.erb
@@ -1,0 +1,7 @@
+<% if meal_plan.archived? %>
+  <span class="inline-flex items-center rounded-full bg-gray-100 px-2.5 py-1 text-xs font-medium text-gray-600">Archived</span>
+<% elsif meal_plan.accepted? %>
+  <span class="inline-flex items-center rounded-full bg-green-50 px-2.5 py-1 text-xs font-medium text-green-700 ring-1 ring-inset ring-green-600/20">Accepted</span>
+<% else %>
+  <span class="inline-flex items-center rounded-full bg-amber-50 px-2.5 py-1 text-xs font-medium text-amber-700 ring-1 ring-inset ring-amber-600/20">Draft</span>
+<% end %>

--- a/app/views/meal_plans/archive.html.erb
+++ b/app/views/meal_plans/archive.html.erb
@@ -1,0 +1,31 @@
+<% content_for :title, "Meal Plan Archive | Second Breakfast" %>
+
+<section class="mx-auto w-full max-w-5xl px-4 py-8 sm:px-6 lg:px-8">
+  <div class="flex items-center gap-x-3">
+    <%= link_to meal_plans_path, class: "text-gray-400 hover:text-gray-600" do %>
+      <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
+      </svg>
+      <span class="sr-only">Back to meal plans</span>
+    <% end %>
+    <h1 class="text-3xl font-bold tracking-tight text-gray-900">Archive</h1>
+  </div>
+  <p class="mt-2 text-gray-600">Past weeks, kept read-only.</p>
+
+  <% if @meal_plans.any? %>
+    <ul class="mt-8 divide-y divide-gray-100 rounded-xl border border-gray-200 bg-white shadow-sm">
+      <% @meal_plans.each do |plan| %>
+        <li>
+          <%= link_to meal_plan_path(plan), class: "flex items-center justify-between px-6 py-4 hover:bg-gray-50" do %>
+            <span class="font-medium text-gray-900">
+              <%= plan.week_start_date.strftime("%-d %b") %> &ndash; <%= plan.week_end_date.strftime("%-d %b %Y") %>
+            </span>
+            <span class="text-sm text-gray-500"><%= pluralize(plan.meal_plan_entries.size, "meal") %></span>
+          <% end %>
+        </li>
+      <% end %>
+    </ul>
+  <% else %>
+    <p class="mt-8 text-sm text-gray-500">No archived weeks yet &mdash; finish a week and it will land here.</p>
+  <% end %>
+</section>

--- a/app/views/meal_plans/index.html.erb
+++ b/app/views/meal_plans/index.html.erb
@@ -1,0 +1,86 @@
+<% content_for :title, "Meal Plans | Second Breakfast" %>
+
+<section class="mx-auto w-full max-w-5xl px-4 py-8 sm:px-6 lg:px-8">
+  <%= render "flash" %>
+
+  <div class="md:flex md:items-center md:justify-between">
+    <div>
+      <h1 class="text-3xl font-bold tracking-tight text-gray-900">Meal Plans</h1>
+      <p class="mt-2 text-gray-600">Plan your week from Monday to Sunday.</p>
+    </div>
+    <% if @archived_count.positive? %>
+      <%= link_to "Archive (#{@archived_count})", archive_meal_plans_path,
+          class: "mt-4 md:mt-0 inline-flex items-center text-sm font-medium text-indigo-600 hover:text-indigo-500" %>
+    <% end %>
+  </div>
+
+  <!-- This week -->
+  <div class="mt-8 overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
+    <div class="border-b border-gray-100 bg-gray-50 px-6 py-3">
+      <h2 class="text-sm font-semibold uppercase tracking-wide text-gray-500">This week</h2>
+    </div>
+    <div class="p-6">
+      <% if @current_plan %>
+        <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <div class="flex items-center gap-x-3">
+              <p class="text-lg font-semibold text-gray-900">
+                <%= @current_plan.week_start_date.strftime("%-d %b") %> &ndash; <%= @current_plan.week_end_date.strftime("%-d %b") %>
+              </p>
+              <%= render "status_pill", meal_plan: @current_plan %>
+            </div>
+            <p class="mt-1 text-sm text-gray-600">
+              <%= pluralize(@current_plan.meal_plan_entries.size, "meal") %> planned
+            </p>
+          </div>
+          <%= link_to "Open this week's plan", meal_plan_path(@current_plan),
+              class: "inline-flex justify-center rounded-md bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500" %>
+        </div>
+      <% else %>
+        <div class="flex flex-col items-start gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <p class="text-gray-600">Nothing planned for this week yet.</p>
+          <%= form_with url: meal_plans_path, class: "contents" do |form| %>
+            <%= form.submit "Plan this week",
+                class: "inline-flex justify-center rounded-md bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 cursor-pointer" %>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+
+  <!-- Upcoming weeks -->
+  <div class="mt-8">
+    <h2 class="text-sm font-semibold uppercase tracking-wide text-gray-500">Upcoming weeks</h2>
+
+    <% if @upcoming_plans.any? %>
+      <ul class="mt-3 divide-y divide-gray-100 rounded-xl border border-gray-200 bg-white shadow-sm">
+        <% @upcoming_plans.each do |plan| %>
+          <li>
+            <%= link_to meal_plan_path(plan), class: "flex items-center justify-between px-6 py-4 hover:bg-gray-50" do %>
+              <div class="flex items-center gap-x-3">
+                <span class="font-medium text-gray-900">
+                  <%= plan.week_start_date.strftime("%-d %b") %> &ndash; <%= plan.week_end_date.strftime("%-d %b") %>
+                </span>
+                <%= render "status_pill", meal_plan: plan %>
+              </div>
+              <span class="text-sm text-gray-500"><%= pluralize(plan.meal_plan_entries.size, "meal") %></span>
+            <% end %>
+          </li>
+        <% end %>
+      </ul>
+    <% else %>
+      <p class="mt-3 text-sm text-gray-500">No future weeks planned.</p>
+    <% end %>
+
+    <%= form_with url: meal_plans_path, class: "mt-4 flex items-end gap-x-2" do |form| %>
+      <div>
+        <%= form.label :week_start_date, "Plan a future week", scope: :meal_plan, class: "block text-sm font-medium text-gray-700" %>
+        <%= form.date_field :week_start_date, name: "meal_plan[week_start_date]", min: Date.current,
+            class: "mt-1 block rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm" %>
+      </div>
+      <%= form.submit "Create plan",
+          class: "rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 cursor-pointer" %>
+    <% end %>
+    <p class="mt-2 text-xs text-gray-500">Pick any date &mdash; the plan snaps to that week's Monday. One plan per week.</p>
+  </div>
+</section>

--- a/app/views/meal_plans/index.html.erb
+++ b/app/views/meal_plans/index.html.erb
@@ -39,9 +39,13 @@
       <% else %>
         <div class="flex flex-col items-start gap-4 sm:flex-row sm:items-center sm:justify-between">
           <p class="text-gray-600">Nothing planned for this week yet.</p>
-          <%= form_with url: meal_plans_path, class: "contents" do |form| %>
+          <%= form_with url: meal_plans_path, class: "flex flex-col items-start gap-2 sm:items-end" do |form| %>
             <%= form.submit "Plan this week",
                 class: "inline-flex justify-center rounded-md bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 cursor-pointer" %>
+            <label class="flex items-center gap-x-2 text-xs text-gray-600">
+              <%= form.check_box :auto_fill, { checked: true, name: "meal_plan[auto_fill]", class: "h-4 w-4 rounded border-gray-300 text-indigo-600" }, "1", "0" %>
+              Pick my meals for me &mdash; a breakfast, lunch and dinner each day
+            </label>
           <% end %>
         </div>
       <% end %>
@@ -80,6 +84,10 @@
       </div>
       <%= form.submit "Create plan",
           class: "rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 cursor-pointer" %>
+      <label class="flex items-center gap-x-2 pb-2.5 text-xs text-gray-600">
+        <%= form.check_box :auto_fill, { checked: true, name: "meal_plan[auto_fill]", class: "h-4 w-4 rounded border-gray-300 text-indigo-600" }, "1", "0" %>
+        Pick my meals for me
+      </label>
     <% end %>
     <p class="mt-2 text-xs text-gray-500">Pick any date &mdash; the plan snaps to that week's Monday. One plan per week.</p>
   </div>

--- a/app/views/meal_plans/show.html.erb
+++ b/app/views/meal_plans/show.html.erb
@@ -34,6 +34,9 @@
         Print
       </button>
       <% if @meal_plan.editable? %>
+        <%= button_to "Auto-fill week", auto_fill_meal_plan_path(@meal_plan), method: :post,
+            class: "rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50",
+            title: "Add a breakfast, lunch and dinner for each day" %>
         <%= button_to "Delete", meal_plan_path(@meal_plan), method: :delete,
             class: "rounded-md bg-white px-3 py-2 text-sm font-semibold text-red-600 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-red-50",
             form: { data: { turbo_confirm: "Delete this meal plan?" } } %>

--- a/app/views/meal_plans/show.html.erb
+++ b/app/views/meal_plans/show.html.erb
@@ -1,0 +1,62 @@
+<% content_for :title, "Meal Plan #{@meal_plan.week_start_date.strftime('%-d %b')} | Second Breakfast" %>
+
+<section class="mx-auto w-full max-w-7xl px-4 py-8 sm:px-6 lg:px-8" data-controller="meal-picker">
+  <%= render "flash" %>
+
+  <% if @meal_plan.archived? %>
+    <div class="mb-6 rounded-md bg-gray-50 px-4 py-3 text-sm text-gray-600 ring-1 ring-inset ring-gray-200">
+      This week is archived &mdash; it's read-only history now.
+    </div>
+  <% end %>
+
+  <div class="md:flex md:items-center md:justify-between">
+    <div>
+      <div class="flex items-center gap-x-3">
+        <%= link_to meal_plans_path, class: "text-gray-400 hover:text-gray-600", title: "All meal plans" do %>
+          <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
+          </svg>
+          <span class="sr-only">Back to meal plans</span>
+        <% end %>
+        <h1 class="text-2xl font-bold tracking-tight text-gray-900">
+          <%= @meal_plan.current_week? ? "This week" : @meal_plan.week_start_date.strftime("Week of %-d %B") %>
+        </h1>
+        <%= render "status_pill", meal_plan: @meal_plan %>
+      </div>
+      <p class="mt-1 text-sm text-gray-500">
+        <%= @meal_plan.week_start_date.strftime("Monday %-d %b") %> &ndash; <%= @meal_plan.week_end_date.strftime("Sunday %-d %b %Y") %>
+      </p>
+    </div>
+
+    <div class="mt-4 flex items-center gap-x-2 md:mt-0 print:hidden">
+      <button data-controller="print" data-action="print#print"
+              class="inline-flex items-center gap-x-1.5 rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50">
+        Print
+      </button>
+      <% if @meal_plan.editable? %>
+        <%= button_to "Delete", meal_plan_path(@meal_plan), method: :delete,
+            class: "rounded-md bg-white px-3 py-2 text-sm font-semibold text-red-600 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-red-50",
+            form: { data: { turbo_confirm: "Delete this meal plan?" } } %>
+        <%= button_to "Accept plan", accept_meal_plan_path(@meal_plan), method: :post,
+            class: "rounded-md bg-indigo-600 px-3.5 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500",
+            form: { data: { turbo_confirm: "Accepting locks the plan. You can reopen it until the week ends." } } %>
+      <% elsif @meal_plan.accepted? && !@meal_plan.archived? %>
+        <%= button_to "Reopen", reopen_meal_plan_path(@meal_plan), method: :post,
+            class: "rounded-md bg-white px-3.5 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50" %>
+      <% end %>
+    </div>
+  </div>
+
+  <!-- The board -->
+  <div class="mt-8 grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-7">
+    <% MealPlanEntry::DAYS.each_index do |day_index| %>
+      <%= render "day_cell", meal_plan: @meal_plan, day_index: day_index, entries: @entries_by_day[day_index] || [] %>
+    <% end %>
+  </div>
+
+  <%= render "shopping_list", meal_plan: @meal_plan %>
+
+  <% if @meal_plan.editable? %>
+    <%= render "picker" %>
+  <% end %>
+</section>

--- a/app/views/meals/index.html.erb
+++ b/app/views/meals/index.html.erb
@@ -5,7 +5,7 @@
 
   <div class="flex items-center justify-between">
     <div class="flex-auto">
-      <h1 class="text-2xl font-semibold leading-6 text-gray-900">Meal Plan</h1>
+      <h1 class="text-2xl font-semibold leading-6 text-gray-900">Saved Recipes</h1>
       <p class="mt-2 text-sm text-gray-700">Your selected meals and shopping list.</p>
     </div>
     <% if @baskets.any? %>
@@ -98,8 +98,8 @@
         <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
         </svg>
-        <h3 class="mt-2 text-sm font-medium text-gray-900">No meals planned</h3>
-        <p class="mt-1 text-sm text-gray-500">Get started by adding some recipes to your meal plan.</p>
+        <h3 class="mt-2 text-sm font-medium text-gray-900">No saved recipes</h3>
+        <p class="mt-1 text-sm text-gray-500">Get started by saving some recipes.</p>
         <div class="mt-6">
           <%= link_to recipes_path, class: "inline-flex items-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600" do %>
             Browse Recipes

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -15,13 +15,13 @@
       <%= button_to toggle_meal_path(recipe_id: @recipe.id),
           method: :post,
           class: "rounded-md px-3.5 py-2.5 bg-green-500 hover:bg-green-400 text-white font-medium inline-flex items-center" do %>
-        <span>In Meal Plan</span>
+        <span>Saved</span>
       <% end %>
     <% else %>
       <%= button_to toggle_meal_path(recipe_id: @recipe.id),
           method: :post,
           class: "rounded-md px-3.5 py-2.5 bg-blue-500 hover:bg-blue-400 text-white font-medium inline-flex items-center" do %>
-        <span>Add to Meal Plan</span>
+        <span>Save Recipe</span>
       <% end %>
     <% end %>
   <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,6 +53,7 @@ Rails.application.routes.draw do
     member do
       post :accept
       post :reopen
+      post :auto_fill
     end
     resources :entries, controller: "meal_plan_entries", only: [ :create, :destroy ]
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,14 @@ Rails.application.routes.draw do
       end
       resources :categories, only: [ :index, :show ]
       resources :baskets, only: [ :index, :create, :destroy ]
+      resources :meal_plans, only: [ :index, :show, :create, :destroy ] do
+        member do
+          post :accept
+          post :reopen
+          get :shopping_list
+        end
+        resources :entries, controller: "meal_plan_entries", only: [ :create, :destroy ]
+      end
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,10 +45,22 @@ Rails.application.routes.draw do
 
   resources :categories
 
-  # Meal plan routes
+  # Weekly meal plans
+  resources :meal_plans, only: [ :index, :show, :create, :destroy ] do
+    collection do
+      get :archive
+    end
+    member do
+      post :accept
+      post :reopen
+    end
+    resources :entries, controller: "meal_plan_entries", only: [ :create, :destroy ]
+  end
+
+  # Saved recipes (legacy basket) — feeds the meal plan picker
   resources :meals, controller: "meals", only: [ :index, :destroy ]
   post "meals/toggle", to: "meals#toggle", as: "toggle_meal"
-  get "meal-plan", to: "meals#index", as: "meal_plan"
+  get "meal-plan", to: redirect("/meal_plans")
 
 
   get "up" => "rails/health#show", as: :rails_health_check

--- a/db/migrate/20260816221135_create_meal_plans.rb
+++ b/db/migrate/20260816221135_create_meal_plans.rb
@@ -1,0 +1,12 @@
+class CreateMealPlans < ActiveRecord::Migration[8.1]
+  def change
+    create_table :meal_plans do |t|
+      t.references :user, null: false, foreign_key: true
+      t.date :week_start_date, null: false
+      t.string :status, null: false, default: "draft"
+
+      t.timestamps
+    end
+    add_index :meal_plans, [ :user_id, :week_start_date ], unique: true
+  end
+end

--- a/db/migrate/20260816221136_create_meal_plan_entries.rb
+++ b/db/migrate/20260816221136_create_meal_plan_entries.rb
@@ -1,0 +1,13 @@
+class CreateMealPlanEntries < ActiveRecord::Migration[8.1]
+  def change
+    create_table :meal_plan_entries do |t|
+      t.references :meal_plan, null: false, foreign_key: true
+      t.references :recipe, null: false, foreign_key: true
+      t.integer :day_of_week, null: false
+
+      t.timestamps
+    end
+    add_index :meal_plan_entries, [ :meal_plan_id, :recipe_id, :day_of_week ],
+              unique: true, name: "index_meal_plan_entries_uniqueness"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_16_195714) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_16_221136) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -81,6 +81,27 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_16_195714) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "meal_plan_entries", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.integer "day_of_week", null: false
+    t.bigint "meal_plan_id", null: false
+    t.bigint "recipe_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["meal_plan_id", "recipe_id", "day_of_week"], name: "index_meal_plan_entries_uniqueness", unique: true
+    t.index ["meal_plan_id"], name: "index_meal_plan_entries_on_meal_plan_id"
+    t.index ["recipe_id"], name: "index_meal_plan_entries_on_recipe_id"
+  end
+
+  create_table "meal_plans", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "status", default: "draft", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.date "week_start_date", null: false
+    t.index ["user_id", "week_start_date"], name: "index_meal_plans_on_user_id_and_week_start_date", unique: true
+    t.index ["user_id"], name: "index_meal_plans_on_user_id"
+  end
+
   create_table "recipes", force: :cascade do |t|
     t.integer "category_id", null: false
     t.datetime "created_at", null: false
@@ -109,5 +130,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_16_195714) do
   add_foreign_key "api_keys", "users"
   add_foreign_key "baskets", "recipes"
   add_foreign_key "baskets", "users"
+  add_foreign_key "meal_plan_entries", "meal_plans"
+  add_foreign_key "meal_plan_entries", "recipes"
+  add_foreign_key "meal_plans", "users"
   add_foreign_key "recipes", "categories"
 end

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -109,6 +109,24 @@ Create a new recipe with all fields. An image is automatically fetched in the ba
 
 **Note:** Recipe creation returns immediately. The image is fetched asynchronously by a background job and will appear shortly after.
 
+### Meal plan tools
+
+Weekly meal plans run Monday–Sunday, one plan per week. Draft plans are editable; accepting locks a plan (reopen until the week ends); past weeks are read-only archive.
+
+- `list_meal_plans` — list plans, newest first (`filter`: `active` / `archived`)
+- `get_meal_plan` — a plan's full Monday–Sunday grid (`id`)
+- `create_meal_plan` — plan a week (`week_start_date` optional; defaults to the current week, any date normalises to Monday; past weeks rejected)
+- `add_meal_to_plan` — add a recipe to a day (`plan_id`, `recipe_id`, `day`)
+- `remove_meal_from_plan` — remove an entry (`plan_id`, `entry_id`)
+- `accept_meal_plan` / `reopen_meal_plan` — lock / unlock a plan (`id`)
+- `get_meal_plan_shopping_list` — aggregated ingredients for the week (`id`)
+
+**Example prompt:**
+```
+Plan next week for me: use my existing recipes, fish twice,
+no beef, and keep breakfasts quick. Then show me the shopping list.
+```
+
 ## Example Workflows
 
 ### Import Recipe from Photo

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -115,13 +115,16 @@ Weekly meal plans run Monday–Sunday, one plan per week. Draft plans are editab
 
 - `list_meal_plans` — list plans, newest first (`filter`: `active` / `archived`)
 - `get_meal_plan` — a plan's full Monday–Sunday grid (`id`)
-- `create_meal_plan` — plan a week (`week_start_date` optional; defaults to the current week, any date normalises to Monday; past weeks rejected)
+- `create_meal_plan` — plan a week (`week_start_date` optional; defaults to the current week, any date normalises to Monday; past weeks rejected). Pass `auto_fill: true` to have the week filled automatically with one breakfast, one lunch and one dinner per day, picked from the user's recipes by category
 - `add_meal_to_plan` — add a recipe to a day (`plan_id`, `recipe_id`, `day`)
 - `remove_meal_from_plan` — remove an entry (`plan_id`, `entry_id`)
 - `accept_meal_plan` / `reopen_meal_plan` — lock / unlock a plan (`id`)
 - `get_meal_plan_shopping_list` — aggregated ingredients for the week (`id`)
 
-**Example prompt:**
+**Example prompts:**
+```
+Plan next week for me automatically — just fill every day.
+```
 ```
 Plan next week for me: use my existing recipes, fish twice,
 no beef, and keep breakfasts quick. Then show me the shopping list.

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -183,6 +183,134 @@ server.tool(
   }
 );
 
+// Meal plan tools.
+// Rules: weeks run Monday-Sunday and one plan exists per week. Only draft
+// plans are editable; accepting locks a plan and reopening is possible until
+// the week ends. Past weeks are read-only archive.
+
+const DAY_ENUM = z.enum(["monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"]);
+
+server.tool(
+  "list_meal_plans",
+  "List the user's weekly meal plans, newest first. Each week runs Monday-Sunday and a user can only have one plan per week.",
+  {
+    filter: z.enum(["active", "archived"]).optional().describe("Optional filter: 'active' for current/future weeks, 'archived' for past weeks"),
+  },
+  async ({ filter }) => {
+    const qs = filter ? `?filter=${filter}` : "";
+    const data = await apiRequest("GET", `/meal_plans${qs}`);
+    return {
+      content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
+    };
+  }
+);
+
+server.tool(
+  "get_meal_plan",
+  "Get a meal plan's full Monday-Sunday grid with the recipes planned for each day.",
+  {
+    id: z.number().describe("Meal plan ID (use list_meal_plans to find)"),
+  },
+  async ({ id }) => {
+    const data = await apiRequest("GET", `/meal_plans/${id}`);
+    return {
+      content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
+    };
+  }
+);
+
+server.tool(
+  "create_meal_plan",
+  "Create a meal plan for a week. Defaults to the current week; pass any date inside a future week to plan ahead (it normalises to that week's Monday). Only one plan can exist per week - if one already exists the error includes it. Past weeks cannot be planned.",
+  {
+    week_start_date: z
+      .string()
+      .optional()
+      .describe("Optional date (YYYY-MM-DD) inside the target week. Omit for the current week."),
+  },
+  async ({ week_start_date }) => {
+    const body = { meal_plan: {} };
+    if (week_start_date) body.meal_plan.week_start_date = week_start_date;
+    const data = await apiRequest("POST", "/meal_plans", body);
+    return {
+      content: [{ type: "text", text: `Meal plan created for week beginning ${data.week_start_date}.\n\n${JSON.stringify(data, null, 2)}` }],
+    };
+  }
+);
+
+server.tool(
+  "add_meal_to_plan",
+  "Add a recipe to a day of a draft meal plan. The same recipe cannot be added twice to one day. Fails if the plan is accepted (reopen it first) or archived.",
+  {
+    plan_id: z.number().describe("Meal plan ID"),
+    recipe_id: z.number().describe("Recipe ID (use search_recipes to find)"),
+    day: DAY_ENUM.describe("Day of the week"),
+  },
+  async ({ plan_id, recipe_id, day }) => {
+    const data = await apiRequest("POST", `/meal_plans/${plan_id}/entries`, { entry: { recipe_id, day } });
+    return {
+      content: [{ type: "text", text: `Added "${data.recipe.title}" to ${data.day}.\n\n${JSON.stringify(data, null, 2)}` }],
+    };
+  }
+);
+
+server.tool(
+  "remove_meal_from_plan",
+  "Remove an entry from a draft meal plan (entry_id comes from get_meal_plan). Fails if the plan is accepted (reopen it first) or archived.",
+  {
+    plan_id: z.number().describe("Meal plan ID"),
+    entry_id: z.number().describe("Entry ID to remove"),
+  },
+  async ({ plan_id, entry_id }) => {
+    await apiRequest("DELETE", `/meal_plans/${plan_id}/entries/${entry_id}`);
+    return {
+      content: [{ type: "text", text: `Entry ${entry_id} removed from meal plan ${plan_id}.` }],
+    };
+  }
+);
+
+server.tool(
+  "accept_meal_plan",
+  "Accept a draft meal plan, locking it against changes. It can be reopened until its week ends.",
+  {
+    id: z.number().describe("Meal plan ID"),
+  },
+  async ({ id }) => {
+    const data = await apiRequest("POST", `/meal_plans/${id}/accept`);
+    return {
+      content: [{ type: "text", text: `Meal plan for week beginning ${data.week_start_date} accepted and locked.\n\n${JSON.stringify(data, null, 2)}` }],
+    };
+  }
+);
+
+server.tool(
+  "reopen_meal_plan",
+  "Reopen an accepted meal plan so it can be edited again. Only works while the plan's week has not ended.",
+  {
+    id: z.number().describe("Meal plan ID"),
+  },
+  async ({ id }) => {
+    const data = await apiRequest("POST", `/meal_plans/${id}/reopen`);
+    return {
+      content: [{ type: "text", text: `Meal plan for week beginning ${data.week_start_date} reopened for editing.\n\n${JSON.stringify(data, null, 2)}` }],
+    };
+  }
+);
+
+server.tool(
+  "get_meal_plan_shopping_list",
+  "Get the aggregated shopping list for a meal plan - every ingredient across the week's recipes, summed by name and unit.",
+  {
+    id: z.number().describe("Meal plan ID"),
+  },
+  async ({ id }) => {
+    const data = await apiRequest("GET", `/meal_plans/${id}/shopping_list`);
+    return {
+      content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
+    };
+  }
+);
+
 // Start the server
 async function main() {
   const transport = new StdioServerTransport();

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -227,10 +227,15 @@ server.tool(
       .string()
       .optional()
       .describe("Optional date (YYYY-MM-DD) inside the target week. Omit for the current week."),
+    auto_fill: z
+      .boolean()
+      .optional()
+      .describe("If true, automatically fills the week with one breakfast, one lunch and one dinner per day, picked from the user's recipes by category."),
   },
-  async ({ week_start_date }) => {
+  async ({ week_start_date, auto_fill }) => {
     const body = { meal_plan: {} };
     if (week_start_date) body.meal_plan.week_start_date = week_start_date;
+    if (auto_fill) body.meal_plan.auto_fill = true;
     const data = await apiRequest("POST", "/meal_plans", body);
     return {
       content: [{ type: "text", text: `Meal plan created for week beginning ${data.week_start_date}.\n\n${JSON.stringify(data, null, 2)}` }],

--- a/spec/factories/meal_plan_entries.rb
+++ b/spec/factories/meal_plan_entries.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :meal_plan_entry do
+    meal_plan
+    recipe
+    day_of_week { 0 }
+  end
+end

--- a/spec/factories/meal_plans.rb
+++ b/spec/factories/meal_plans.rb
@@ -1,0 +1,16 @@
+FactoryBot.define do
+  factory :meal_plan do
+    user
+    week_start_date { Date.current.beginning_of_week(:monday) }
+    status { "draft" }
+
+    trait :accepted do
+      status { "accepted" }
+    end
+
+    trait :archived do
+      week_start_date { 2.weeks.ago.to_date.beginning_of_week(:monday) }
+      to_create { |instance| instance.save!(validate: false) }
+    end
+  end
+end

--- a/spec/models/meal_plan_entry_spec.rb
+++ b/spec/models/meal_plan_entry_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe MealPlanEntry, type: :model do
+  let(:plan) { create(:meal_plan) }
+
+  describe "day handling" do
+    it "maps day names to indexes with Monday as 0" do
+      expect(described_class.day_index("monday")).to eq(0)
+      expect(described_class.day_index("Sunday")).to eq(6)
+      expect(described_class.day_index("notaday")).to be_nil
+    end
+
+    it "exposes day_name" do
+      entry = create(:meal_plan_entry, meal_plan: plan, day_of_week: 4)
+
+      expect(entry.day_name).to eq("friday")
+    end
+
+    it "rejects out-of-range days" do
+      expect(build(:meal_plan_entry, meal_plan: plan, day_of_week: 7)).not_to be_valid
+    end
+  end
+
+  describe "uniqueness" do
+    it "rejects the same recipe twice on the same day" do
+      entry = create(:meal_plan_entry, meal_plan: plan)
+      duplicate = build(:meal_plan_entry, meal_plan: plan, recipe: entry.recipe, day_of_week: entry.day_of_week)
+
+      expect(duplicate).not_to be_valid
+      expect(duplicate.errors[:recipe_id]).to include("is already planned for that day")
+    end
+
+    it "allows the same recipe on a different day" do
+      entry = create(:meal_plan_entry, meal_plan: plan)
+
+      expect(build(:meal_plan_entry, meal_plan: plan, recipe: entry.recipe, day_of_week: 3)).to be_valid
+    end
+  end
+
+  describe "editability guards" do
+    it "rejects creation on an accepted plan" do
+      accepted = create(:meal_plan, :accepted)
+      entry = build(:meal_plan_entry, meal_plan: accepted)
+
+      expect(entry).not_to be_valid
+      expect(entry.errors[:base]).to include("meal plan is not editable")
+    end
+
+    it "rejects destroy on a locked plan" do
+      entry = create(:meal_plan_entry, meal_plan: plan)
+      plan.accept!
+
+      expect(entry.destroy).to be(false)
+      expect(entry.errors[:base]).to include("meal plan is not editable")
+      expect(described_class.exists?(entry.id)).to be(true)
+    end
+
+    it "allows destroy while draft" do
+      entry = create(:meal_plan_entry, meal_plan: plan)
+
+      expect { entry.destroy }.to change(described_class, :count).by(-1)
+    end
+  end
+end

--- a/spec/models/meal_plan_spec.rb
+++ b/spec/models/meal_plan_spec.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe MealPlan, type: :model do
+  include ActiveSupport::Testing::TimeHelpers
+
+  let(:user) { create(:user) }
+  let(:monday) { Date.current.beginning_of_week(:monday) }
+
+  describe "week normalisation" do
+    it "normalises any date to that week's Monday" do
+      plan = create(:meal_plan, user: user, week_start_date: monday + 3.days)
+
+      expect(plan.week_start_date).to eq(monday)
+    end
+
+    it "exposes normalize_week_start as a class method" do
+      expect(described_class.normalize_week_start(monday + 6.days)).to eq(monday)
+    end
+
+    it "computes week_end_date as the following Sunday" do
+      plan = create(:meal_plan, user: user)
+
+      expect(plan.week_end_date).to eq(monday + 6.days)
+      expect(plan.week_end_date.sunday?).to be(true)
+    end
+  end
+
+  describe "uniqueness" do
+    it "allows only one plan per user per week" do
+      create(:meal_plan, user: user)
+      duplicate = build(:meal_plan, user: user, week_start_date: monday + 2.days)
+
+      expect(duplicate).not_to be_valid
+      expect(duplicate.errors[:week_start_date]).to include("already has a plan for this week")
+    end
+
+    it "allows different users to plan the same week" do
+      create(:meal_plan, user: user)
+
+      expect(build(:meal_plan, week_start_date: monday)).to be_valid
+    end
+  end
+
+  describe "past week rejection" do
+    it "rejects creating a plan for a past week" do
+      plan = build(:meal_plan, user: user, week_start_date: 1.week.ago)
+
+      expect(plan).not_to be_valid
+      expect(plan.errors[:week_start_date]).to include("cannot be in a past week")
+    end
+
+    it "allows future weeks" do
+      expect(build(:meal_plan, user: user, week_start_date: 3.weeks.from_now)).to be_valid
+    end
+
+    it "supports the :archived factory trait via validate: false" do
+      plan = create(:meal_plan, :archived, user: user)
+
+      expect(plan).to be_persisted
+      expect(plan.archived?).to be(true)
+    end
+  end
+
+  describe "lifecycle" do
+    it "accepts a draft plan" do
+      plan = create(:meal_plan, user: user)
+
+      expect(plan.accept!).to be(true)
+      expect(plan.reload).to be_accepted
+    end
+
+    it "does not accept an already accepted plan" do
+      plan = create(:meal_plan, :accepted, user: user)
+
+      expect(plan.accept!).to be(false)
+    end
+
+    it "reopens an accepted plan" do
+      plan = create(:meal_plan, :accepted, user: user)
+
+      expect(plan.reopen!).to be(true)
+      expect(plan.reload).to be_draft
+    end
+
+    it "does not reopen a draft plan" do
+      plan = create(:meal_plan, user: user)
+
+      expect(plan.reopen!).to be(false)
+    end
+
+    it "refuses accept and reopen on archived plans" do
+      plan = create(:meal_plan, user: user)
+
+      travel_to(2.weeks.from_now) do
+        expect(plan.accept!).to be(false)
+        plan.update_column(:status, "accepted")
+        expect(plan.reopen!).to be(false)
+      end
+    end
+  end
+
+  describe "date-derived states" do
+    it "derives archived? once the week has fully passed" do
+      plan = create(:meal_plan, user: user)
+
+      expect(plan.archived?).to be(false)
+
+      travel_to(plan.week_end_date + 1.day) do
+        expect(plan.archived?).to be(true)
+        expect(plan.editable?).to be(false)
+        expect(plan.locked?).to be(true)
+      end
+    end
+
+    it "stays current until Sunday ends" do
+      plan = create(:meal_plan, user: user)
+
+      travel_to(plan.week_end_date) do
+        expect(plan.archived?).to be(false)
+        expect(plan.current_week?).to be(true)
+      end
+    end
+
+    it "scopes archived and active by the current Monday" do
+      current = create(:meal_plan, user: user)
+      old = create(:meal_plan, :archived, user: user)
+
+      expect(described_class.archived).to contain_exactly(old)
+      expect(described_class.active).to contain_exactly(current)
+    end
+
+    it "orders newest week first" do
+      current = create(:meal_plan, user: user)
+      upcoming = create(:meal_plan, user: user, week_start_date: 1.week.from_now)
+
+      expect(described_class.ordered).to eq([ upcoming, current ])
+    end
+  end
+
+  describe "#aggregated_ingredients" do
+    it "counts a recipe once per planned day" do
+      recipe = create(:recipe, ingredients: [ { "name" => "onion", "quantity" => "1", "unit" => "whole" } ])
+      plan = create(:meal_plan, user: user)
+      create(:meal_plan_entry, meal_plan: plan, recipe: recipe, day_of_week: 0)
+      create(:meal_plan_entry, meal_plan: plan, recipe: recipe, day_of_week: 1)
+
+      onion = plan.aggregated_ingredients.find { |i| i[:name] == "onion" }
+      expect(onion[:quantity]).to eq(2.0)
+      expect(onion[:unit]).to eq("whole")
+    end
+  end
+end

--- a/spec/models/meal_plan_spec.rb
+++ b/spec/models/meal_plan_spec.rb
@@ -139,6 +139,58 @@ RSpec.describe MealPlan, type: :model do
     end
   end
 
+  describe "#auto_fill!" do
+    let!(:breakfast) { create(:category, name: "Breakfast") }
+    let!(:dinner) { create(:category, name: "Dinner") }
+    let(:plan) { create(:meal_plan, user: user) }
+
+    before do
+      create_list(:recipe, 2, category: breakfast)
+      create_list(:recipe, 3, category: dinner)
+    end
+
+    it "adds one recipe per matching slot per day, skipping empty slots" do
+      expect(plan.auto_fill!).to be(true)
+
+      # breakfast + dinner have recipes, lunch has none: 2 slots x 7 days
+      expect(plan.meal_plan_entries.count).to eq(14)
+      (0..6).each do |day|
+        day_categories = plan.meal_plan_entries.where(day_of_week: day).map { |e| e.recipe.category.name }
+        expect(day_categories).to contain_exactly("Breakfast", "Dinner")
+      end
+    end
+
+    it "treats Main Course recipes as dinners" do
+      Category.find_by(name: "Dinner").update!(name: "Main Course")
+
+      plan.auto_fill!
+
+      expect(plan.recipes.joins(:category).where(categories: { name: "Main Course" }).count).to be_positive
+    end
+
+    it "spreads recipes rather than repeating one" do
+      plan.auto_fill!
+
+      dinner_recipe_ids = plan.meal_plan_entries.joins(recipe: :category)
+                              .where(categories: { name: "Dinner" }).pluck(:recipe_id)
+      expect(dinner_recipe_ids.uniq.size).to eq(3)
+    end
+
+    it "skips entries that clash with existing ones and keeps them" do
+      existing = create(:meal_plan_entry, meal_plan: plan, recipe: Recipe.first, day_of_week: 0)
+
+      expect(plan.auto_fill!).to be(true)
+      expect(MealPlanEntry.exists?(existing.id)).to be(true)
+    end
+
+    it "refuses on a locked plan" do
+      plan.accept!
+
+      expect(plan.auto_fill!).to be(false)
+      expect(plan.meal_plan_entries.count).to eq(0)
+    end
+  end
+
   describe "#aggregated_ingredients" do
     it "counts a recipe once per planned day" do
       recipe = create(:recipe, ingredients: [ { "name" => "onion", "quantity" => "1", "unit" => "whole" } ])

--- a/spec/requests/api/v1/meal_plans_spec.rb
+++ b/spec/requests/api/v1/meal_plans_spec.rb
@@ -83,7 +83,8 @@ RSpec.describe "Api::V1::MealPlans", type: :request do
           meal_plan: {
             type: :object,
             properties: {
-              week_start_date: { type: :string, format: "date", description: "Any date in the target week; normalised to Monday. Defaults to the current week." }
+              week_start_date: { type: :string, format: "date", description: "Any date in the target week; normalised to Monday. Defaults to the current week." },
+              auto_fill: { type: :boolean, description: "Automatically fill the week with one breakfast, lunch and dinner per day, picked by category." }
             }
           }
         }
@@ -105,6 +106,17 @@ RSpec.describe "Api::V1::MealPlans", type: :request do
 
         run_test! do |response|
           expect(response.parsed_body["week_start_date"]).to eq(monday.iso8601)
+        end
+      end
+
+      response "201", "auto-fills the week when requested" do
+        let(:meal_plan) { { meal_plan: { auto_fill: true } } }
+
+        before { create(:recipe, category: create(:category, name: "Breakfast")) }
+
+        run_test! do |response|
+          days = response.parsed_body["days"]
+          expect(days.values.sum(&:size)).to eq(7)
         end
       end
 

--- a/spec/requests/api/v1/meal_plans_spec.rb
+++ b/spec/requests/api/v1/meal_plans_spec.rb
@@ -1,0 +1,383 @@
+# frozen_string_literal: true
+
+require "swagger_helper"
+
+RSpec.describe "Api::V1::MealPlans", type: :request do
+  let(:api_key) { create(:api_key) }
+  let(:user) { api_key.user }
+  let(:Authorization) { "Bearer #{api_key.token}" }
+  let(:monday) { Date.current.beginning_of_week(:monday) }
+
+  path "/api/v1/meal_plans" do
+    get "List meal plans" do
+      tags "Meal Plans"
+      produces "application/json"
+      security [ bearer_auth: [] ]
+      parameter name: :filter, in: :query, type: :string, required: false,
+                description: "Filter by timeframe: active or archived"
+      parameter name: :page, in: :query, type: :integer, required: false
+
+      response "200", "meal plans found" do
+        schema type: :object,
+               properties: {
+                 meal_plans: {
+                   type: :array,
+                   items: {
+                     type: :object,
+                     properties: {
+                       id: { type: :integer },
+                       week_start_date: { type: :string, format: "date" },
+                       week_end_date: { type: :string, format: "date" },
+                       status: { type: :string, enum: %w[draft accepted] },
+                       archived: { type: :boolean },
+                       editable: { type: :boolean },
+                       entry_count: { type: :integer }
+                     }
+                   }
+                 },
+                 meta: { "$ref" => "#/components/schemas/Pagination" }
+               }
+
+        before do
+          create(:meal_plan, user: user)
+          create(:meal_plan, :archived, user: user)
+        end
+
+        run_test! do |response|
+          expect(response.parsed_body["meal_plans"].size).to eq(2)
+        end
+      end
+
+      response "200", "filtered to archived plans" do
+        let(:filter) { "archived" }
+
+        before do
+          create(:meal_plan, user: user)
+          create(:meal_plan, :archived, user: user)
+        end
+
+        run_test! do |response|
+          plans = response.parsed_body["meal_plans"]
+          expect(plans.size).to eq(1)
+          expect(plans.first["archived"]).to be(true)
+        end
+      end
+
+      response "401", "unauthorized" do
+        schema "$ref" => "#/components/schemas/Error"
+
+        let(:Authorization) { "Bearer invalid" }
+
+        run_test!
+      end
+    end
+
+    post "Create a meal plan" do
+      tags "Meal Plans"
+      consumes "application/json"
+      produces "application/json"
+      security [ bearer_auth: [] ]
+      parameter name: :meal_plan, in: :body, schema: {
+        type: :object,
+        properties: {
+          meal_plan: {
+            type: :object,
+            properties: {
+              week_start_date: { type: :string, format: "date", description: "Any date in the target week; normalised to Monday. Defaults to the current week." }
+            }
+          }
+        }
+      }
+
+      response "201", "meal plan created" do
+        let(:meal_plan) { { meal_plan: { week_start_date: (monday + 1.week + 3.days).iso8601 } } }
+
+        run_test! do |response|
+          body = response.parsed_body
+          expect(body["week_start_date"]).to eq((monday + 1.week).iso8601)
+          expect(body["status"]).to eq("draft")
+          expect(body["days"].keys).to eq(MealPlanEntry::DAYS)
+        end
+      end
+
+      response "201", "defaults to the current week" do
+        let(:meal_plan) { { meal_plan: {} } }
+
+        run_test! do |response|
+          expect(response.parsed_body["week_start_date"]).to eq(monday.iso8601)
+        end
+      end
+
+      response "409", "week already planned" do
+        schema type: :object,
+               properties: {
+                 error: { type: :string },
+                 meal_plan: { type: :object }
+               }
+
+        let(:meal_plan) { { meal_plan: { week_start_date: monday.iso8601 } } }
+
+        before { create(:meal_plan, user: user, week_start_date: monday) }
+
+        run_test! do |response|
+          expect(response.parsed_body["meal_plan"]["week_start_date"]).to eq(monday.iso8601)
+        end
+      end
+
+      response "422", "past week rejected" do
+        schema "$ref" => "#/components/schemas/ValidationErrors"
+
+        let(:meal_plan) { { meal_plan: { week_start_date: (monday - 1.week).iso8601 } } }
+
+        run_test!
+      end
+
+      response "401", "unauthorized" do
+        schema "$ref" => "#/components/schemas/Error"
+
+        let(:Authorization) { "Bearer invalid" }
+        let(:meal_plan) { { meal_plan: {} } }
+
+        run_test!
+      end
+    end
+  end
+
+  path "/api/v1/meal_plans/{id}" do
+    parameter name: :id, in: :path, type: :integer, required: true
+
+    get "Show a meal plan" do
+      tags "Meal Plans"
+      produces "application/json"
+      security [ bearer_auth: [] ]
+
+      response "200", "meal plan found" do
+        let(:plan) { create(:meal_plan, user: user) }
+        let(:id) { plan.id }
+
+        before { create(:meal_plan_entry, meal_plan: plan, day_of_week: 2) }
+
+        run_test! do |response|
+          body = response.parsed_body
+          expect(body["days"]["wednesday"].size).to eq(1)
+          expect(body["days"]["wednesday"].first["recipe"]).to include("id", "title", "serves")
+        end
+      end
+
+      response "404", "not found or not owned" do
+        schema "$ref" => "#/components/schemas/Error"
+
+        let(:id) { create(:meal_plan).id }
+
+        run_test!
+      end
+    end
+
+    delete "Delete a meal plan" do
+      tags "Meal Plans"
+      produces "application/json"
+      security [ bearer_auth: [] ]
+
+      response "204", "draft plan deleted" do
+        let(:id) { create(:meal_plan, user: user).id }
+
+        run_test!
+      end
+
+      response "422", "locked plan cannot be deleted" do
+        schema "$ref" => "#/components/schemas/ValidationErrors"
+
+        let(:id) { create(:meal_plan, :accepted, user: user).id }
+
+        run_test!
+      end
+    end
+  end
+
+  path "/api/v1/meal_plans/{id}/accept" do
+    parameter name: :id, in: :path, type: :integer, required: true
+
+    post "Accept a meal plan" do
+      tags "Meal Plans"
+      produces "application/json"
+      security [ bearer_auth: [] ]
+
+      response "200", "plan accepted" do
+        let(:id) { create(:meal_plan, user: user).id }
+
+        run_test! do |response|
+          expect(response.parsed_body["status"]).to eq("accepted")
+          expect(response.parsed_body["editable"]).to be(false)
+        end
+      end
+
+      response "422", "already accepted" do
+        schema "$ref" => "#/components/schemas/ValidationErrors"
+
+        let(:id) { create(:meal_plan, :accepted, user: user).id }
+
+        run_test!
+      end
+    end
+  end
+
+  path "/api/v1/meal_plans/{id}/reopen" do
+    parameter name: :id, in: :path, type: :integer, required: true
+
+    post "Reopen an accepted meal plan" do
+      tags "Meal Plans"
+      produces "application/json"
+      security [ bearer_auth: [] ]
+
+      response "200", "plan reopened" do
+        let(:id) { create(:meal_plan, :accepted, user: user).id }
+
+        run_test! do |response|
+          expect(response.parsed_body["status"]).to eq("draft")
+        end
+      end
+
+      response "422", "draft plans cannot be reopened" do
+        schema "$ref" => "#/components/schemas/ValidationErrors"
+
+        let(:id) { create(:meal_plan, user: user).id }
+
+        run_test!
+      end
+    end
+  end
+
+  path "/api/v1/meal_plans/{id}/shopping_list" do
+    parameter name: :id, in: :path, type: :integer, required: true
+
+    get "Aggregated shopping list for a meal plan" do
+      tags "Meal Plans"
+      produces "application/json"
+      security [ bearer_auth: [] ]
+
+      response "200", "shopping list" do
+        schema type: :object,
+               properties: {
+                 week_start_date: { type: :string, format: "date" },
+                 ingredients: {
+                   type: :array,
+                   items: {
+                     type: :object,
+                     properties: {
+                       name: { type: :string },
+                       quantity: { type: :number },
+                       unit: { type: :string, nullable: true }
+                     }
+                   }
+                 }
+               }
+
+        let(:plan) { create(:meal_plan, user: user) }
+        let(:id) { plan.id }
+
+        before do
+          recipe = create(:recipe, ingredients: [ { "name" => "onion", "quantity" => "2", "unit" => "whole" } ])
+          create(:meal_plan_entry, meal_plan: plan, recipe: recipe)
+        end
+
+        run_test! do |response|
+          expect(response.parsed_body["ingredients"]).to contain_exactly(
+            a_hash_including("name" => "onion", "quantity" => 2.0)
+          )
+        end
+      end
+    end
+  end
+
+  path "/api/v1/meal_plans/{meal_plan_id}/entries" do
+    parameter name: :meal_plan_id, in: :path, type: :integer, required: true
+
+    post "Add a recipe to a day" do
+      tags "Meal Plans"
+      consumes "application/json"
+      produces "application/json"
+      security [ bearer_auth: [] ]
+      parameter name: :entry, in: :body, schema: {
+        type: :object,
+        properties: {
+          entry: {
+            type: :object,
+            properties: {
+              recipe_id: { type: :integer },
+              day: { type: :string, enum: MealPlanEntry::DAYS }
+            },
+            required: %w[recipe_id day]
+          }
+        }
+      }
+
+      let(:plan) { create(:meal_plan, user: user) }
+      let(:meal_plan_id) { plan.id }
+      let(:recipe) { create(:recipe) }
+
+      response "201", "entry added" do
+        let(:entry) { { entry: { recipe_id: recipe.id, day: "wednesday" } } }
+
+        run_test! do |response|
+          expect(response.parsed_body["day"]).to eq("wednesday")
+          expect(response.parsed_body["recipe"]["id"]).to eq(recipe.id)
+        end
+      end
+
+      response "422", "invalid day name" do
+        schema "$ref" => "#/components/schemas/ValidationErrors"
+
+        let(:entry) { { entry: { recipe_id: recipe.id, day: "someday" } } }
+
+        run_test!
+      end
+
+      response "422", "locked plan rejects entries" do
+        let(:plan) { create(:meal_plan, :accepted, user: user) }
+        let(:entry) { { entry: { recipe_id: recipe.id, day: "monday" } } }
+
+        run_test!
+      end
+    end
+  end
+
+  path "/api/v1/meal_plans/{meal_plan_id}/entries/{id}" do
+    parameter name: :meal_plan_id, in: :path, type: :integer, required: true
+    parameter name: :id, in: :path, type: :integer, required: true
+
+    delete "Remove a recipe from a day" do
+      tags "Meal Plans"
+      produces "application/json"
+      security [ bearer_auth: [] ]
+
+      let(:plan) { create(:meal_plan, user: user) }
+      let(:meal_plan_id) { plan.id }
+
+      response "204", "entry removed" do
+        let(:id) { create(:meal_plan_entry, meal_plan: plan).id }
+
+        run_test!
+      end
+
+      response "422", "locked plan rejects removal" do
+        schema "$ref" => "#/components/schemas/ValidationErrors"
+
+        let(:id) do
+          entry = create(:meal_plan_entry, meal_plan: plan)
+          plan.accept!
+          entry.id
+        end
+
+        run_test!
+      end
+
+      response "404", "entry not found" do
+        schema "$ref" => "#/components/schemas/Error"
+
+        let(:id) { 0 }
+
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/requests/meal_plans_spec.rb
+++ b/spec/requests/meal_plans_spec.rb
@@ -1,0 +1,157 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "MealPlans", type: :request do
+  include ActiveSupport::Testing::TimeHelpers
+
+  let(:user) { create(:user) }
+  let(:monday) { Date.current.beginning_of_week(:monday) }
+
+  describe "authentication" do
+    it "redirects every action to sign-in when logged out" do
+      get meal_plans_path
+      expect(response).to redirect_to(sign_in_path)
+
+      post meal_plans_path
+      expect(response).to redirect_to(sign_in_path)
+
+      get archive_meal_plans_path
+      expect(response).to redirect_to(sign_in_path)
+    end
+  end
+
+  describe "POST /meal_plans" do
+    before { sign_in(user) }
+
+    it "creates a plan for the current week by default" do
+      post meal_plans_path
+
+      plan = user.meal_plans.sole
+      expect(plan.week_start_date).to eq(monday)
+      expect(response).to redirect_to(meal_plan_path(plan))
+    end
+
+    it "normalises any date to that week's Monday" do
+      post meal_plans_path, params: { meal_plan: { week_start_date: (monday + 1.week + 4.days).iso8601 } }
+
+      expect(user.meal_plans.sole.week_start_date).to eq(monday + 1.week)
+    end
+
+    it "redirects to the existing plan when the week is already planned" do
+      existing = create(:meal_plan, user: user)
+
+      expect {
+        post meal_plans_path, params: { meal_plan: { week_start_date: (monday + 2.days).iso8601 } }
+      }.not_to change(MealPlan, :count)
+
+      expect(response).to redirect_to(meal_plan_path(existing))
+    end
+
+    it "rejects past weeks" do
+      expect {
+        post meal_plans_path, params: { meal_plan: { week_start_date: (monday - 1.week).iso8601 } }
+      }.not_to change(MealPlan, :count)
+
+      expect(response).to redirect_to(meal_plans_path)
+    end
+  end
+
+  describe "lifecycle actions" do
+    before { sign_in(user) }
+
+    it "accepts and reopens a plan" do
+      plan = create(:meal_plan, user: user)
+
+      post accept_meal_plan_path(plan)
+      expect(plan.reload).to be_accepted
+
+      post reopen_meal_plan_path(plan)
+      expect(plan.reload).to be_draft
+    end
+
+    it "blocks destroy on an accepted plan" do
+      plan = create(:meal_plan, :accepted, user: user)
+
+      expect { delete meal_plan_path(plan) }.not_to change(MealPlan, :count)
+      expect(response).to redirect_to(meal_plan_path(plan))
+    end
+
+    it "destroys a draft plan" do
+      plan = create(:meal_plan, user: user)
+
+      expect { delete meal_plan_path(plan) }.to change(MealPlan, :count).by(-1)
+    end
+
+    it "404s on another user's plan" do
+      other = create(:meal_plan)
+
+      get meal_plan_path(other)
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe "GET /meal_plans/archive" do
+    before { sign_in(user) }
+
+    it "lists only past weeks" do
+      create(:meal_plan, user: user)
+      old = create(:meal_plan, :archived, user: user)
+
+      get archive_meal_plans_path
+
+      expect(response.body).to include(old.week_start_date.strftime("%-d %b"))
+      expect(response.body).not_to include("This week")
+    end
+  end
+
+  describe "entries" do
+    before { sign_in(user) }
+
+    let(:plan) { create(:meal_plan, user: user) }
+    let(:recipe) { create(:recipe) }
+
+    it "adds a recipe to a day" do
+      post meal_plan_entries_path(plan), params: { entry: { recipe_id: recipe.id, day: "wednesday" } }
+
+      entry = plan.meal_plan_entries.sole
+      expect(entry.day_name).to eq("wednesday")
+      expect(entry.recipe).to eq(recipe)
+    end
+
+    it "removes an entry" do
+      entry = create(:meal_plan_entry, meal_plan: plan)
+
+      expect {
+        delete meal_plan_entry_path(plan, entry)
+      }.to change(MealPlanEntry, :count).by(-1)
+    end
+
+    it "rejects mutations on a locked plan" do
+      entry = create(:meal_plan_entry, meal_plan: plan)
+      plan.accept!
+
+      post meal_plan_entries_path(plan), params: { entry: { recipe_id: recipe.id, day: "monday" } }
+      expect(plan.meal_plan_entries.count).to eq(1)
+
+      delete meal_plan_entry_path(plan, entry)
+      expect(MealPlanEntry.exists?(entry.id)).to be(true)
+    end
+
+    it "rejects an invalid day name" do
+      post meal_plan_entries_path(plan), params: { entry: { recipe_id: recipe.id, day: "funday" } }
+
+      expect(plan.meal_plan_entries.count).to eq(0)
+      expect(response).to redirect_to(meal_plan_path(plan))
+    end
+
+    it "404s on another user's plan" do
+      other_plan = create(:meal_plan)
+
+      post meal_plan_entries_path(other_plan), params: { entry: { recipe_id: recipe.id, day: "monday" } }
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end

--- a/spec/requests/meal_plans_spec.rb
+++ b/spec/requests/meal_plans_spec.rb
@@ -24,11 +24,33 @@ RSpec.describe "MealPlans", type: :request do
   describe "POST /meal_plans" do
     before { sign_in(user) }
 
-    it "creates a plan for the current week by default" do
+    it "creates a plan for the current week and auto-fills it by default" do
+      breakfast = create(:category, name: "Breakfast")
+      create(:recipe, category: breakfast)
+
       post meal_plans_path
 
       plan = user.meal_plans.sole
       expect(plan.week_start_date).to eq(monday)
+      expect(plan.meal_plan_entries.count).to eq(7)
+      expect(response).to redirect_to(meal_plan_path(plan))
+    end
+
+    it "creates an empty plan when auto-fill is unticked" do
+      create(:recipe, category: create(:category, name: "Breakfast"))
+
+      post meal_plans_path, params: { meal_plan: { auto_fill: "0" } }
+
+      expect(user.meal_plans.sole.meal_plan_entries.count).to eq(0)
+    end
+
+    it "auto-fills an existing draft plan via the board action" do
+      create(:recipe, category: create(:category, name: "Dinner"))
+      plan = create(:meal_plan, user: user)
+
+      post auto_fill_meal_plan_path(plan)
+
+      expect(plan.meal_plan_entries.count).to eq(7)
       expect(response).to redirect_to(meal_plan_path(plan))
     end
 

--- a/spec/requests/meals_spec.rb
+++ b/spec/requests/meals_spec.rb
@@ -4,40 +4,40 @@ RSpec.describe "Meals" do
   let(:user) { create(:user) }
   let(:recipe) { create(:recipe) }
 
-  describe "GET /meal-plan" do
+  describe "GET /meals" do
     context "when authenticated" do
       before { sign_in(user) }
 
       it "returns success" do
-        get meal_plan_path
+        get meals_path
         expect(response).to have_http_status(:success)
       end
 
       it "displays empty state when no meals planned" do
-        get meal_plan_path
-        expect(response.body).to include("No meals planned")
+        get meals_path
+        expect(response.body).to include("No saved recipes")
       end
 
       context "with meals in the plan" do
         let!(:basket) { create(:basket, user: user, recipe: recipe) }
 
         it "displays the recipe" do
-          get meal_plan_path
+          get meals_path
           expect(response.body).to include(recipe.title)
         end
 
         it "displays serves information" do
-          get meal_plan_path
+          get meals_path
           expect(response.body).to include("Serves #{recipe.serves}")
         end
 
         it "displays prep time" do
-          get meal_plan_path
+          get meals_path
           expect(response.body).to include(recipe.prep_time)
         end
 
         it "displays shopping list section" do
-          get meal_plan_path
+          get meals_path
           expect(response.body).to include("Shopping List")
         end
       end
@@ -45,7 +45,7 @@ RSpec.describe "Meals" do
 
     context "when not authenticated" do
       it "redirects to login" do
-        get meal_plan_path
+        get meals_path
         expect(response).to redirect_to(sign_in_path)
       end
     end
@@ -64,15 +64,15 @@ RSpec.describe "Meals" do
           }.to change(user.baskets, :count).by(-1)
         end
 
-        it "redirects to meal plan" do
+        it "redirects to saved recipes" do
           delete meal_path(basket), params: { recipe_id: recipe.id }
-          expect(response).to redirect_to(meal_plan_path)
+          expect(response).to redirect_to(meals_path)
         end
 
         it "shows success notice" do
           delete meal_path(basket), params: { recipe_id: recipe.id }
           follow_redirect!
-          expect(response.body).to include("Recipe removed from your meal plan!")
+          expect(response.body).to include("Recipe removed from your saved recipes!")
         end
       end
     end
@@ -101,7 +101,7 @@ RSpec.describe "Meals" do
         it "shows add message" do
           post toggle_meal_path, params: { recipe_id: recipe.id }
           follow_redirect!
-          expect(response.body).to include("Recipe added to your meal plan!")
+          expect(response.body).to include("Recipe saved!")
         end
       end
 
@@ -117,7 +117,7 @@ RSpec.describe "Meals" do
         it "shows remove message" do
           post toggle_meal_path, params: { recipe_id: recipe.id }
           follow_redirect!
-          expect(response.body).to include("Recipe removed from your meal plan!")
+          expect(response.body).to include("Recipe removed from your saved recipes!")
         end
       end
 

--- a/spec/system/baskets_spec.rb
+++ b/spec/system/baskets_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Baskets", type: :system do
       visit recipes_path
 
       # User starts with 0 meals
-      expect(page).to have_content("0 Meals")
+      expect(page).to have_content("0 Saved Recipes")
     end
 
     it "updates basket count when adding a recipe" do
@@ -20,7 +20,7 @@ RSpec.describe "Baskets", type: :system do
 
       visit recipes_path
 
-      expect(page).to have_content("1 Meal")
+      expect(page).to have_content("1 Saved Recipe")
     end
 
     it "shows multiple meals when basket has multiple recipes" do
@@ -29,7 +29,7 @@ RSpec.describe "Baskets", type: :system do
 
       visit recipes_path
 
-      expect(page).to have_content("3 Meals")
+      expect(page).to have_content("3 Saved Recipes")
     end
   end
 

--- a/spec/system/meal_plans_spec.rb
+++ b/spec/system/meal_plans_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Weekly meal plans", type: :system do
+  let(:user) { create(:user) }
+  let!(:recipe) { create(:recipe, title: "Lentil Soup") }
+
+  before { sign_in_as(user) }
+
+  it "creates this week's plan and manages meals on the board" do
+    visit meal_plans_path
+
+    click_button "Plan this week"
+    expect(page).to have_content("This week")
+    expect(page).to have_content("Draft")
+
+    # Add a recipe to Monday via the picker
+    within("#day-monday") { click_button "Add" }
+    fill_in placeholder: "Search recipes…", with: "Lentil"
+    click_button "Lentil Soup"
+
+    within("#day-monday") { expect(page).to have_link("Lentil Soup") }
+
+    # Shopping list reflects the plan
+    expect(page).to have_content("Shopping List")
+
+    # Remove it again
+    within("#day-monday") do
+      accept_confirm { find("button[title='Remove Lentil Soup']").click }
+      expect(page).not_to have_link("Lentil Soup")
+    end
+  end
+
+  it "accepts a plan, locking the board, then reopens it" do
+    plan = create(:meal_plan, user: user)
+    create(:meal_plan_entry, meal_plan: plan, recipe: recipe, day_of_week: 0)
+
+    visit meal_plan_path(plan)
+
+    accept_confirm { click_button "Accept plan" }
+    expect(page).to have_content("Accepted")
+    expect(page).not_to have_button("Add")
+    expect(page).not_to have_css("button[title='Remove Lentil Soup']")
+
+    click_button "Reopen"
+    expect(page).to have_content("Draft")
+    expect(page).to have_button("Add", minimum: 1)
+  end
+
+  it "shows archived plans read-only" do
+    plan = create(:meal_plan, :archived, user: user)
+    MealPlanEntry.insert!({
+      meal_plan_id: plan.id, recipe_id: recipe.id, day_of_week: 2,
+      created_at: Time.current, updated_at: Time.current
+    })
+
+    visit meal_plan_path(plan)
+
+    expect(page).to have_content("This week is archived")
+    expect(page).to have_content("Archived")
+    expect(page).to have_link("Lentil Soup")
+    expect(page).not_to have_button("Add")
+    expect(page).not_to have_button("Accept plan")
+    expect(page).not_to have_button("Reopen")
+  end
+
+  it "prevents planning the same week twice" do
+    create(:meal_plan, user: user)
+
+    visit meal_plans_path
+
+    expect(page).not_to have_button("Plan this week")
+    expect(page).to have_link("Open this week's plan")
+  end
+end

--- a/spec/system/navigation_spec.rb
+++ b/spec/system/navigation_spec.rb
@@ -7,10 +7,11 @@ RSpec.describe "Navigation", type: :system do
     context "when signed in" do
       before { sign_in_as(user) }
 
-      it "displays the meal plan link in the main nav" do
+      it "displays the meal plan and saved recipes links in the main nav" do
         visit root_path
-        expect(page).to have_link(href: meal_plan_path)
-        expect(page).to have_content("0 Meals")
+        expect(page).to have_link(href: meal_plans_path)
+        expect(page).to have_link(href: meals_path)
+        expect(page).to have_content("0 Saved Recipes")
       end
 
       it "displays the user email as a dropdown trigger" do
@@ -67,15 +68,15 @@ RSpec.describe "Navigation", type: :system do
       create(:basket, user: user, recipe: recipe)
 
       visit root_path
-      expect(page).to have_content("1 Meal")
+      expect(page).to have_content("1 Saved Recipe")
     end
 
-    it "shows plural for multiple meals" do
+    it "shows plural for multiple saved recipes" do
       recipes = create_list(:recipe, 3)
       recipes.each { |r| create(:basket, user: user, recipe: r) }
 
       visit root_path
-      expect(page).to have_content("3 Meals")
+      expect(page).to have_content("3 Saved Recipes")
     end
   end
 end

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -256,7 +256,7 @@ paths:
       parameters: []
       responses:
         '201':
-          description: defaults to the current week
+          description: auto-fills the week when requested
         '409':
           description: week already planned
           content:
@@ -294,6 +294,10 @@ paths:
                       format: date
                       description: Any date in the target week; normalised to Monday.
                         Defaults to the current week.
+                    auto_fill:
+                      type: boolean
+                      description: Automatically fill the week with one breakfast,
+                        lunch and dinner per day, picked by category.
   "/api/v1/meal_plans/{id}":
     parameters:
     - name: id

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -188,6 +188,309 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/Error"
+  "/api/v1/meal_plans":
+    get:
+      summary: List meal plans
+      tags:
+      - Meal Plans
+      security:
+      - bearer_auth: []
+      parameters:
+      - name: filter
+        in: query
+        required: false
+        description: 'Filter by timeframe: active or archived'
+        schema:
+          type: string
+      - name: page
+        in: query
+        required: false
+        schema:
+          type: integer
+      responses:
+        '200':
+          description: filtered to archived plans
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  meal_plans:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: integer
+                        week_start_date:
+                          type: string
+                          format: date
+                        week_end_date:
+                          type: string
+                          format: date
+                        status:
+                          type: string
+                          enum:
+                          - draft
+                          - accepted
+                        archived:
+                          type: boolean
+                        editable:
+                          type: boolean
+                        entry_count:
+                          type: integer
+                  meta:
+                    "$ref": "#/components/schemas/Pagination"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+    post:
+      summary: Create a meal plan
+      tags:
+      - Meal Plans
+      security:
+      - bearer_auth: []
+      parameters: []
+      responses:
+        '201':
+          description: defaults to the current week
+        '409':
+          description: week already planned
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  meal_plan:
+                    type: object
+        '422':
+          description: past week rejected
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ValidationErrors"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                meal_plan:
+                  type: object
+                  properties:
+                    week_start_date:
+                      type: string
+                      format: date
+                      description: Any date in the target week; normalised to Monday.
+                        Defaults to the current week.
+  "/api/v1/meal_plans/{id}":
+    parameters:
+    - name: id
+      in: path
+      required: true
+      schema:
+        type: integer
+    get:
+      summary: Show a meal plan
+      tags:
+      - Meal Plans
+      security:
+      - bearer_auth: []
+      responses:
+        '200':
+          description: meal plan found
+        '404':
+          description: not found or not owned
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+    delete:
+      summary: Delete a meal plan
+      tags:
+      - Meal Plans
+      security:
+      - bearer_auth: []
+      responses:
+        '204':
+          description: draft plan deleted
+        '422':
+          description: locked plan cannot be deleted
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ValidationErrors"
+  "/api/v1/meal_plans/{id}/accept":
+    parameters:
+    - name: id
+      in: path
+      required: true
+      schema:
+        type: integer
+    post:
+      summary: Accept a meal plan
+      tags:
+      - Meal Plans
+      security:
+      - bearer_auth: []
+      responses:
+        '200':
+          description: plan accepted
+        '422':
+          description: already accepted
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ValidationErrors"
+  "/api/v1/meal_plans/{id}/reopen":
+    parameters:
+    - name: id
+      in: path
+      required: true
+      schema:
+        type: integer
+    post:
+      summary: Reopen an accepted meal plan
+      tags:
+      - Meal Plans
+      security:
+      - bearer_auth: []
+      responses:
+        '200':
+          description: plan reopened
+        '422':
+          description: draft plans cannot be reopened
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ValidationErrors"
+  "/api/v1/meal_plans/{id}/shopping_list":
+    parameters:
+    - name: id
+      in: path
+      required: true
+      schema:
+        type: integer
+    get:
+      summary: Aggregated shopping list for a meal plan
+      tags:
+      - Meal Plans
+      security:
+      - bearer_auth: []
+      responses:
+        '200':
+          description: shopping list
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  week_start_date:
+                    type: string
+                    format: date
+                  ingredients:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        quantity:
+                          type: number
+                        unit:
+                          type: string
+                          nullable: true
+  "/api/v1/meal_plans/{meal_plan_id}/entries":
+    parameters:
+    - name: meal_plan_id
+      in: path
+      required: true
+      schema:
+        type: integer
+    post:
+      summary: Add a recipe to a day
+      tags:
+      - Meal Plans
+      security:
+      - bearer_auth: []
+      parameters: []
+      responses:
+        '201':
+          description: entry added
+        '422':
+          description: locked plan rejects entries
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ValidationErrors"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                entry:
+                  type: object
+                  properties:
+                    recipe_id:
+                      type: integer
+                    day:
+                      type: string
+                      enum:
+                      - monday
+                      - tuesday
+                      - wednesday
+                      - thursday
+                      - friday
+                      - saturday
+                      - sunday
+                  required:
+                  - recipe_id
+                  - day
+  "/api/v1/meal_plans/{meal_plan_id}/entries/{id}":
+    parameters:
+    - name: meal_plan_id
+      in: path
+      required: true
+      schema:
+        type: integer
+    - name: id
+      in: path
+      required: true
+      schema:
+        type: integer
+    delete:
+      summary: Remove a recipe from a day
+      tags:
+      - Meal Plans
+      security:
+      - bearer_auth: []
+      responses:
+        '204':
+          description: entry removed
+        '422':
+          description: locked plan rejects removal
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ValidationErrors"
+        '404':
+          description: entry not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
   "/api/v1/recipes":
     get:
       summary: List recipes


### PR DESCRIPTION
## Summary
- Adds `MealPlan` + `MealPlanEntry`: one plan per user per week (Monday-normalised, DB-unique), creatable for the current or future weeks only
- Draft plans are editable; accepting locks the plan; reopening allowed until the week ends; past weeks become read-only archive purely by date — no jobs, no cron
- New Monday–Sunday board UI: this-week-first index, per-day recipe picker (saved recipes pool + search), Turbo-stream add/remove, accept/reopen flow, archive page, per-plan shopping list with print/copy
- Full JSON API (`/api/v1/meal_plans` + entries, accept/reopen/shopping_list, duplicate week → 409 surfacing the existing plan) and MCP tools so Claude can plan and accept a week conversationally
- `Basket` survives as the saved-recipes pool feeding quick-add (rebranded 'Saved Recipes'; old `/meal-plan` URL redirects to the new board)

## Test plan
- [x] `bundle exec rspec` — 370 examples green: model, request, rswag, and system specs (includes `travel_to` coverage of date-derived archiving)
- [x] `bundle exec rubocop` and `bin/brakeman --no-pager` clean
- [ ] Manual: create this week's plan, fill days, accept → locked, reopen, verify duplicate-week creation is impossible (UI/API/DB) and last week's plan shows in the archive read-only
- [ ] MCP: build + accept a week via the new tools against a local server

Closes #139, closes #140, closes #141. Part of #142.

🤖 Generated with [Claude Code](https://claude.com/claude-code)