### PR TITLE
🎨 Add About and Colophon pages with a personal footer

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -8,4 +8,10 @@ class PagesController < ApplicationController
 
   def terms
   end
+
+  def about
+  end
+
+  def colophon
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -167,10 +167,12 @@
 <footer class="bg-white">
     <div class="mx-auto mt-8 max-w-7xl border-t border-gray-900/10 px-6 py-8 md:flex md:items-center md:justify-between lg:px-8">
       <div class="flex gap-x-6 md:order-2">
+        <%= link_to "About", about_path, class: "text-sm/6 text-gray-600 hover:text-gray-900" %>
+        <%= link_to "Colophon", colophon_path, class: "text-sm/6 text-gray-600 hover:text-gray-900" %>
         <%= link_to "Privacy", privacy_path, class: "text-sm/6 text-gray-600 hover:text-gray-900" %>
         <%= link_to "Terms", terms_path, class: "text-sm/6 text-gray-600 hover:text-gray-900" %>
       </div>
-      <p class="mt-8 text-sm/6 text-gray-600 md:order-1 md:mt-0">&copy; <%= Date.current.year %> swm.cc, Made with ❤️ in NI.</p>
+      <p class="mt-8 text-sm/6 text-gray-600 md:order-1 md:mt-0">Built with ❤️ by <%= link_to "swmcc", "https://swm.cc", class: "font-medium text-gray-900 hover:text-indigo-600" %></p>
     </div>
 </footer>
 

--- a/app/views/pages/about.html.erb
+++ b/app/views/pages/about.html.erb
@@ -1,0 +1,27 @@
+<% content_for :title, "About | Second Breakfast" %>
+
+<article class="mx-auto max-w-3xl space-y-8 text-gray-700">
+  <header>
+    <h1 class="text-3xl font-bold tracking-tight text-gray-900">About Second Breakfast</h1>
+  </header>
+
+  <section class="space-y-3">
+    <p>Second Breakfast is my personal recipe collection and meal planner. It holds the recipes I actually cook &mdash; a lot of them chosen to be kind to type 2 diabetes &mdash; and turns them into a plan for the week ahead.</p>
+  </section>
+
+  <section class="space-y-3">
+    <h2 class="text-xl font-semibold text-gray-900">How I use it</h2>
+    <p>Every week gets a meal plan running Monday to Sunday. I can fill it by hand, or let the app pick a breakfast, lunch and dinner for each day from my recipes. Once a plan looks right I accept it, which locks it in; finished weeks archive themselves into read-only history. Each plan rolls its ingredients up into a shopping list I can print or copy.</p>
+  </section>
+
+  <section class="space-y-3">
+    <h2 class="text-xl font-semibold text-gray-900">The Claude integration</h2>
+    <p>The part I enjoy most: the site ships with an <a href="https://modelcontextprotocol.io" class="font-medium text-indigo-600 hover:text-indigo-500">MCP (Model Context Protocol)</a> server, which means <a href="https://claude.ai" class="font-medium text-indigo-600 hover:text-indigo-500">Claude</a> can use it directly. I photograph a recipe from a cookbook, hand it to Claude, and it extracts the ingredients, instructions and nutrition and files the recipe here &mdash; image included.</p>
+    <p>Claude can also plan whole weeks conversationally (&ldquo;plan next week, fish twice, no beef&rdquo;) and read back the shopping list. Everything goes through the same JSON API, authenticated with revocable API keys I manage from my account page.</p>
+  </section>
+
+  <section class="space-y-3">
+    <h2 class="text-xl font-semibold text-gray-900">What I'm eating</h2>
+    <p>The current week's plan is syndicated to <a href="https://swm.cc" class="font-medium text-indigo-600 hover:text-indigo-500">swm.cc</a>, so anyone curious can see what's on the menu.</p>
+  </section>
+</article>

--- a/app/views/pages/colophon.html.erb
+++ b/app/views/pages/colophon.html.erb
@@ -1,0 +1,46 @@
+<% content_for :title, "Colophon | Second Breakfast" %>
+
+<article class="mx-auto max-w-3xl space-y-8 text-gray-700">
+  <header>
+    <h1 class="text-3xl font-bold tracking-tight text-gray-900">Colophon</h1>
+    <p class="mt-2 text-sm text-gray-500">The technical details behind this site.</p>
+  </header>
+
+  <section class="space-y-3">
+    <h2 class="text-xl font-semibold text-gray-900">Technology Stack</h2>
+    <ul class="list-disc space-y-1 pl-5">
+      <li><strong class="font-medium text-gray-900">Framework:</strong> Rails 8.1 with Hotwire (Turbo + Stimulus)</li>
+      <li><strong class="font-medium text-gray-900">Styling:</strong> Tailwind CSS</li>
+      <li><strong class="font-medium text-gray-900">Database:</strong> PostgreSQL, with Solid Queue, Solid Cache and Solid Cable riding on it &mdash; no Redis</li>
+      <li><strong class="font-medium text-gray-900">Storage:</strong> Active Storage on Amazon S3</li>
+      <li><strong class="font-medium text-gray-900">Hosting:</strong> <a href="https://hatchbox.io" class="font-medium text-indigo-600 hover:text-indigo-500">Hatchbox</a></li>
+    </ul>
+  </section>
+
+  <section class="space-y-3">
+    <h2 class="text-xl font-semibold text-gray-900">Typography</h2>
+    <p>This site uses <a href="https://rsms.me/inter/" class="font-medium text-indigo-600 hover:text-indigo-500">Inter</a>, self-hosted as a variable font so the strict Content Security Policy stays intact.</p>
+  </section>
+
+  <section class="space-y-3">
+    <h2 class="text-xl font-semibold text-gray-900">Features</h2>
+    <ul class="list-disc space-y-1 pl-5">
+      <li>Weekly Monday&ndash;Sunday meal plans with auto-fill</li>
+      <li>Recipe import from photos via a bundled MCP server for Claude</li>
+      <li>Automatic recipe images via the Pexels API</li>
+      <li>Aggregated shopping lists with print and copy</li>
+      <li>A documented JSON API with revocable keys</li>
+      <li>Public syndication of the current week's plan</li>
+    </ul>
+  </section>
+
+  <section class="space-y-3">
+    <h2 class="text-xl font-semibold text-gray-900">Privacy</h2>
+    <p>No tracking, no analytics, no third-party requests. A strict Content Security Policy and full API authentication.</p>
+  </section>
+
+  <section class="space-y-3">
+    <h2 class="text-xl font-semibold text-gray-900">Source Code</h2>
+    <p>This project is open source and available on <a href="https://github.com/swmcc/second_breakfast" class="font-medium text-indigo-600 hover:text-indigo-500">GitHub</a>.</p>
+  </section>
+</article>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,8 @@ Rails.application.routes.draw do
 
   get "privacy", to: "pages#privacy"
   get "terms", to: "pages#terms"
+  get "about", to: "pages#about"
+  get "colophon", to: "pages#colophon"
   get "account", to: "users#show", as: :account
   get "account/export", to: "users#export", as: :account_export
   delete "account", to: "users#destroy"

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -15,6 +15,33 @@ RSpec.describe "Pages" do
       expect(response).to have_http_status(:ok)
       expect(response.body).to include("Terms of Use")
     end
+
+    it "renders the about page while signed out" do
+      get about_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("About Second Breakfast")
+      expect(response.body).to include("MCP (Model Context Protocol)")
+    end
+
+    it "renders the colophon while signed out" do
+      get colophon_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("The technical details behind this site.")
+      expect(response.body).to include("github.com/swmcc/second_breakfast")
+    end
+  end
+
+  describe "footer" do
+    it "links About, Colophon and swm.cc" do
+      get privacy_path
+
+      expect(response.body).to include(%(href="/about"))
+      expect(response.body).to include(%(href="/colophon"))
+      expect(response.body).to include(%(href="https://swm.cc"))
+      expect(response.body).to include("Built with")
+    end
   end
 
   describe "GET / (root)" do


### PR DESCRIPTION
## Summary
- Footer now reads **About · Colophon · Privacy · Terms** with **Built with ❤️ by [swmcc](https://swm.cc)** replacing the old copyright line
- **/about**: what Second Breakfast is for, how the weekly planning works, and the Claude MCP integration (photo → recipe, conversational meal planning), plus the swm.cc syndication
- **/colophon**: mirrors t.swm.cc's structure — Technology Stack, Typography (self-hosted Inter), Features, Privacy, Source Code (public GitHub repo)
- Both pages publicly accessible, styled to match the existing privacy/terms pages

## Test plan
- [x] 391 examples green (new request specs: both pages render signed-out, footer links present)
- [x] RuboCop + Brakeman clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)