### PR TITLE
📌 Pin pagy to 9.x and document the v43 migration path

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,11 @@ updates:
     open-pull-requests-limit: 5
     commit-message:
       prefix: "⬆️"
+    ignore:
+      # Pinned to pagy 9.x on purpose - v43 is a full API redesign.
+      # See UPGRADE_NOTES.md and issue #124 before lifting this.
+      - dependency-name: "pagy"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: github-actions
     directory: "/"

--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem "rswag-api"
 gem "rswag-ui"
 
 # Pagination
-gem "pagy", "~> 9.0"
+gem "pagy", "~> 9.4"
 
 # CORS support
 gem "rack-cors"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -425,6 +425,7 @@ GEM
 PLATFORMS
   arm64-darwin-23
   arm64-darwin-24
+  arm64-darwin-25
   x86_64-linux
 
 DEPENDENCIES
@@ -441,7 +442,7 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   kamal
-  pagy (~> 9.0)
+  pagy (~> 9.4)
   pg (~> 1.6)
   propshaft
   puma (>= 5.0)

--- a/UPGRADE_NOTES.md
+++ b/UPGRADE_NOTES.md
@@ -77,3 +77,70 @@ The application will be available at http://localhost:3000
 - You may see PATH warnings from RVM - these are informational and don't affect functionality
 - Tailwindcss-rails was downgraded to 3.3.2 to match the funeralsni project setup
 - All Solid gems (solid_cache, solid_queue, solid_cable) are configured for production use
+
+---
+
+# Deferred: pagy v43 (issue #124)
+
+**Decision (2026-08-21): stay on pagy 9.x.** The Gemfile pins `gem "pagy", "~> 9.4"`
+and `.github/dependabot.yml` ignores `version-update:semver-major` for pagy, so
+Dependabot will keep proposing 9.x patches but stop proposing v43.
+
+## Why we pinned
+
+Dependabot proposed pagy 9.4.0 -> 43.6.1 (PR #121). That is not a routine bump: v43 is
+a full redesign of the public API, and every pagination call site in this app uses the
+old one. Pinning keeps the JSON API stable and buys time to do the migration as a
+deliberate piece of work rather than as a merged dependency PR.
+
+`pagy` has no 10.x-42.x releases; 9.4.0 is the last release of the 9 series, so the pin
+is effectively "frozen at the last stable version of the old API".
+
+## What pagy v43 changes
+
+| pagy 9.x (what we use) | pagy v43 |
+|---|---|
+| `include Pagy::Backend` | `include Pagy::Method` |
+| `@pagy, @records = pagy(scope)` | `@pagy, @records = pagy(:offset, scope)` |
+| `Pagy::DEFAULT[:limit] = 20` | `Pagy::OPTIONS[:limit] = 20` |
+| `require "pagy/extras/metadata"` / `require "pagy/extras/overflow"` | extras are autoloaded; the explicit requires are removed |
+| `include Pagy::Frontend` in helpers, `pagy_nav(@pagy)` | frontend helpers moved/renamed under the new `Pagy::Method` surface |
+| Instance readers (`pagy.page`, `pagy.pages`, `pagy.count`, `pagy.limit`) | mostly retained, but signatures around `vars`/options changed - re-verify each one |
+
+Upstream guide: https://ddnexus.github.io/pagy/guides/upgrade-guide/
+
+## What would have to change here when we do upgrade
+
+Current pagy touch points:
+
+- `Gemfile` - the `~> 9.4` pin.
+- `.github/dependabot.yml` - remove the pagy `ignore` entry.
+- `config/initializers/pagy.rb` - drop the two `require "pagy/extras/..."` lines and
+  move `Pagy::DEFAULT[:limit]` / `Pagy::DEFAULT[:overflow]` to `Pagy::OPTIONS`.
+- `app/controllers/api/v1/base_controller.rb` - `include Pagy::Backend` becomes
+  `include Pagy::Method`; `rescue_from Pagy::OverflowError` needs re-checking against
+  the v43 overflow handling; the hand-rolled `pagy_metadata` helper builds
+  `{ current_page:, total_pages:, total_count:, per_page: }` from `pagy.page`,
+  `pagy.pages`, `pagy.count`, `pagy.limit`.
+- `app/controllers/api/v1/recipes_controller.rb` (`#index`, `#search`),
+  `app/controllers/api/v1/categories_controller.rb` (`#show`),
+  `app/controllers/api/v1/meal_plans_controller.rb` (`#index`) - each `pagy(scope)`
+  call becomes `pagy(:offset, scope)`.
+- Any HTML pagination added later (recipes index) - the frontend helpers changed too.
+
+## Guardrails
+
+`spec/requests/api/v1/pagination_spec.rb` asserts the exact JSON pagination payload
+(`current_page`, `total_pages`, `total_count`, `per_page`) for the recipes index,
+recipe search, category show, and meal plan index, plus the configured defaults
+(limit 20, overflow `:last_page`). A future major bump that silently reshapes the
+payload will fail there instead of shipping.
+
+## Known gaps (unchanged by this pin)
+
+- The Swagger docs advertise a `limit` query parameter on `GET /api/v1/recipes`, but
+  page size is not actually caller-configurable: that requires
+  `require "pagy/extras/limit"`, which we do not load. Page size is fixed at 20.
+- `config/initializers/pagy.rb` previously set `Pagy::DEFAULT[:items]`, which pagy 9
+  ignores entirely (the option was renamed to `:limit` in pagy 9.0). It happened to be
+  harmless because 20 is also pagy's built-in default; it is now set as `:limit`.

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -36,7 +36,7 @@ module Api
           current_page: pagy.page,
           total_pages: pagy.pages,
           total_count: pagy.count,
-          per_page: pagy.vars[:limit]
+          per_page: pagy.limit
         }
       end
 

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
+# Pinned to pagy 9.x — see UPGRADE_NOTES.md for the v43 migration path.
+# In pagy 9 the page-size option is :limit (it was :items in pagy 8 and earlier);
+# setting :items here would be silently ignored.
 require "pagy/extras/metadata"
 require "pagy/extras/overflow"
 
-Pagy::DEFAULT[:items] = 20
+Pagy::DEFAULT[:limit] = 20
 Pagy::DEFAULT[:overflow] = :last_page

--- a/spec/requests/api/v1/pagination_spec.rb
+++ b/spec/requests/api/v1/pagination_spec.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Guards the pagy 9.x pagination contract for the JSON API.
+#
+# The app is deliberately pinned to pagy 9.x (see UPGRADE_NOTES.md). pagy v43
+# renames Pagy::Backend to Pagy::Method and changes pagy(collection) to
+# pagy(:offset, collection), so an accidental major bump must fail here loudly
+# rather than silently reshaping the payload.
+RSpec.describe "Api::V1 pagination", type: :request do
+  let(:api_key) { create(:api_key) }
+  let(:user) { api_key.user }
+  let(:headers) { { "Authorization" => "Bearer #{api_key.token}", "Accept" => "application/json" } }
+
+  def pagination_from(body)
+    body["pagination"] || body["meta"]
+  end
+
+  describe "configuration" do
+    it "defaults to 20 records per page" do
+      expect(Pagy::DEFAULT[:limit]).to eq(20)
+    end
+
+    it "clamps overflowing pages to the last page" do
+      expect(Pagy::DEFAULT[:overflow]).to eq(:last_page)
+    end
+  end
+
+  describe "GET /api/v1/recipes" do
+    before { create_list(:recipe, 25) }
+
+    it "returns the first page with the full pagination payload" do
+      get "/api/v1/recipes", headers: headers
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["recipes"].size).to eq(20)
+      expect(pagination_from(response.parsed_body)).to eq(
+        "current_page" => 1,
+        "total_pages" => 2,
+        "total_count" => 25,
+        "per_page" => 20
+      )
+    end
+
+    it "honours the page parameter" do
+      get "/api/v1/recipes", params: { page: 2 }, headers: headers
+
+      expect(response.parsed_body["recipes"].size).to eq(5)
+      expect(pagination_from(response.parsed_body)).to include(
+        "current_page" => 2,
+        "total_pages" => 2,
+        "total_count" => 25,
+        "per_page" => 20
+      )
+    end
+
+    it "returns the last page rather than raising when the page overflows" do
+      get "/api/v1/recipes", params: { page: 99 }, headers: headers
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["recipes"].size).to eq(5)
+      expect(pagination_from(response.parsed_body)).to include("current_page" => 2, "total_pages" => 2)
+    end
+
+    it "reports a single empty page when there is nothing to paginate" do
+      Recipe.delete_all
+
+      get "/api/v1/recipes", headers: headers
+
+      expect(response.parsed_body["recipes"]).to be_empty
+      expect(pagination_from(response.parsed_body)).to include(
+        "current_page" => 1,
+        "total_pages" => 1,
+        "total_count" => 0,
+        "per_page" => 20
+      )
+    end
+  end
+
+  describe "GET /api/v1/recipes/search" do
+    it "paginates search results with the same payload shape" do
+      create_list(:recipe, 21, title: "Paginated pancakes")
+      create(:recipe, title: "Unrelated stew")
+
+      get "/api/v1/recipes/search", params: { query: "Paginated" }, headers: headers
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["recipes"].size).to eq(20)
+      expect(pagination_from(response.parsed_body)).to include(
+        "current_page" => 1,
+        "total_pages" => 2,
+        "total_count" => 21,
+        "per_page" => 20
+      )
+    end
+  end
+
+  describe "GET /api/v1/categories/:id" do
+    it "paginates the category's recipes" do
+      category = create(:category)
+      create_list(:recipe, 22, category: category)
+
+      get "/api/v1/categories/#{category.id}", headers: headers
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["recipes"].size).to eq(20)
+      expect(pagination_from(response.parsed_body)).to eq(
+        "current_page" => 1,
+        "total_pages" => 2,
+        "total_count" => 22,
+        "per_page" => 20
+      )
+    end
+  end
+
+  describe "GET /api/v1/meal_plans" do
+    it "returns the pagination payload under meta" do
+      create(:meal_plan, user: user)
+      create(:meal_plan, :archived, user: user)
+
+      get "/api/v1/meal_plans", headers: headers
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["meal_plans"].size).to eq(2)
+      expect(response.parsed_body["meta"]).to eq(
+        "current_page" => 1,
+        "total_pages" => 1,
+        "total_count" => 2,
+        "per_page" => 20
+      )
+    end
+  end
+end


### PR DESCRIPTION
Closes #124

Repo owner picked **Option 4: pin to pagy 9.x**. This does that, plus the guardrails so a future accidental major bump fails loudly.

## What this does

- **`Gemfile`**: `gem "pagy", "~> 9.0"` -> `gem "pagy", "~> 9.4"`. `bundle update pagy` kept us on **9.4.0** — that is the last release of the 9 series (pagy jumps straight from 9.4.0 to 43.0.0), so the lockfile version is unchanged and only the dependency constraint moves.
- **`.github/dependabot.yml`**: added an `ignore` entry under the `bundler` ecosystem for `pagy` / `version-update:semver-major`, with a comment pointing at `UPGRADE_NOTES.md`. 9.x patches will still be proposed.
- **`config/initializers/pagy.rb`**: fixed a latent no-op — the initializer set `Pagy::DEFAULT[:items] = 20`, but pagy 9 renamed that option to `:limit` and ignores `:items` entirely. It was harmless only because 20 is also pagy's built-in default. Now set as `Pagy::DEFAULT[:limit] = 20`. No behaviour change.
- **`app/controllers/api/v1/base_controller.rb`**: `pagy_metadata` now reads `pagy.limit` (the public reader) instead of `pagy.vars[:limit]`. No behaviour change.
- **`spec/requests/api/v1/pagination_spec.rb`** (new, 9 examples): asserts the exact pagination payload — `current_page`, `total_pages`, `total_count`, `per_page` — for the recipes index, recipe search, category show (`pagination` key) and meal plans index (`meta` key), plus page navigation, the configured `:last_page` overflow behaviour, the empty-collection case, and the two configured defaults. The existing rswag specs only checked the JSON *shape* via `$ref`, never the values.
- **`UPGRADE_NOTES.md`**: new "Deferred: pagy v43 (issue #124)" section — why we pinned, the v43 API changes (`Pagy::Backend` -> `Pagy::Method`, `pagy(collection)` -> `pagy(:offset, collection)`, `Pagy::DEFAULT` -> `Pagy::OPTIONS`, extras autoloaded), and a file-by-file list of what has to change here when we do upgrade.

## Verified

No pagy 9.4 deprecations affect what we use: `Pagy::Backend`, `pagy(scope)`, `Pagy::OverflowError`, `pagy/extras/metadata`, `pagy/extras/overflow`, and the `page`/`pages`/`count`/`limit` readers are all current in 9.4.0.

- `bundle exec rspec` — **400 examples, 0 failures**
- `bundle exec rubocop` — **133 files, no offenses**

## Housekeeping

**Dependabot PR #121 (pagy 9.4.0 -> 43.6.1) should be closed** once this merges — the new `ignore` rule stops it being reopened.

## Deliberately not done

- **Did not upgrade to v43, kaminari, or will_paginate.** Owner decision.
- **Did not add `pagy/extras/limit`.** The Swagger docs advertise a `limit` query param on `GET /api/v1/recipes`, but without that extra pagy never reads it — page size is fixed at 20. Fixing it is a behaviour change, not a pin; noted under "Known gaps" in `UPGRADE_NOTES.md`.
- **Did not touch HTML pagination.** Issue #63 is adding it in parallel against the pagy 9 API; this pin keeps that API in place.
