### PR TITLE
✨ Paginate the recipes list and search

### DIFF
--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -1,10 +1,14 @@
 class RecipesController < ApplicationController
+  # Included here rather than in ApplicationController: only the recipe list
+  # and search need a paginated backend.
+  include Pagy::Backend
+
   before_action :authenticate_user!, only: [ :new, :create, :edit, :update, :destroy ]
   before_action :set_recipe, only: %i[ show edit update destroy ]
 
   # GET /recipes or /recipes.json
   def index
-    @recipes = Recipe.all
+    @pagy, @recipes = paginate_recipes(Recipe.all)
   end
 
   # GET /recipes/1 or /recipes/1.json
@@ -67,12 +71,26 @@ class RecipesController < ApplicationController
       else
         @recipes = Recipe.where("LOWER(title) LIKE LOWER(?) OR LOWER(json_extract(ingredients, '$')) LIKE LOWER(?)", query, query)
       end
+
+      @pagy, @recipes = paginate_recipes(@recipes)
     else
+      # No query: nothing to paginate (an Array has no Pagy).
+      @pagy = nil
       @recipes = []
     end
   end
 
   private
+    # Shared pagination for the recipe list and search results: preloads the
+    # category to avoid an N+1 on the cards and applies a deterministic order
+    # so page boundaries are stable.
+    def paginate_recipes(scope)
+      pagy(
+        scope.includes(:category).order(created_at: :desc, id: :desc),
+        limit: Rails.application.config.x.recipes_per_page
+      )
+    end
+
     # Use callbacks to share common setup or constraints between actions.
     def set_recipe
       @recipe = Recipe.find(params.expect(:id))

--- a/app/views/recipes/index.html.erb
+++ b/app/views/recipes/index.html.erb
@@ -57,4 +57,7 @@
       <p class="text-center my-10">No recipes found.</p>
     <% end %>
 
+  </div>
+
+  <%= render "shared/pagination", pagy: @pagy %>
 </div>

--- a/app/views/recipes/search.html.erb
+++ b/app/views/recipes/search.html.erb
@@ -58,4 +58,6 @@
       <p>No results found for "<%= params[:query] %>". Try searching with different keywords.</p>
     </div>
   <% end %>
+
+  <%= render "shared/pagination", pagy: @pagy %>
 <% end %>

--- a/app/views/shared/_pagination.html.erb
+++ b/app/views/shared/_pagination.html.erb
@@ -1,0 +1,46 @@
+<%#
+  Reusable pagination nav.
+
+  Usage: render "shared/pagination", pagy: @pagy
+
+  `pagy` may be nil (e.g. a blank search that never built a relation), in which
+  case nothing is rendered. Links keep the current query string — notably
+  `query` on the search page — so paging never drops the user's filters.
+%>
+<% pagy = local_assigns[:pagy] %>
+<% if pagy.present? && pagy.pages > 1 %>
+  <% page_url = ->(page) { url_for(request.query_parameters.merge("page" => page)) } %>
+  <% edge_classes = "inline-flex items-center rounded-md px-3.5 py-2.5 text-sm font-medium" %>
+
+  <nav class="mt-10 flex items-center justify-between border-t border-gray-200 pt-6" aria-label="Pagination">
+    <div class="flex w-0 flex-1">
+      <% if pagy.prev %>
+        <%= link_to "← Previous", page_url.call(pagy.prev), rel: "prev", class: "#{edge_classes} text-gray-700 hover:bg-gray-50" %>
+      <% else %>
+        <span class="<%= edge_classes %> text-gray-300" aria-disabled="true">← Previous</span>
+      <% end %>
+    </div>
+
+    <div class="hidden md:flex md:items-center md:gap-x-1">
+      <% pagy.series.each do |item| %>
+        <% if item == :gap %>
+          <span class="px-3.5 py-2.5 text-sm font-medium text-gray-400">…</span>
+        <% elsif item.is_a?(String) %>
+          <span aria-current="page" class="rounded-md bg-blue-600 px-3.5 py-2.5 text-sm font-semibold text-white"><%= item %></span>
+        <% else %>
+          <%= link_to item, page_url.call(item), class: "rounded-md px-3.5 py-2.5 text-sm font-medium text-gray-700 hover:bg-gray-50", aria: { label: "Page #{item}" } %>
+        <% end %>
+      <% end %>
+    </div>
+
+    <p class="text-sm text-gray-500 md:hidden">Page <%= pagy.page %> of <%= pagy.pages %></p>
+
+    <div class="flex w-0 flex-1 justify-end">
+      <% if pagy.next %>
+        <%= link_to "Next →", page_url.call(pagy.next), rel: "next", class: "#{edge_classes} text-gray-700 hover:bg-gray-50" %>
+      <% else %>
+        <span class="<%= edge_classes %> text-gray-300" aria-disabled="true">Next →</span>
+      <% end %>
+    </div>
+  </nav>
+<% end %>

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -5,3 +5,10 @@ require "pagy/extras/overflow"
 
 Pagy::DEFAULT[:items] = 20
 Pagy::DEFAULT[:overflow] = :last_page
+
+# Items per page for the HTML recipes list (index + search).
+#
+# Kept separate from Pagy::DEFAULT so the JSON API keeps its own page size:
+# 12 is a clean multiple of the 1/2/3-column Tailwind grid used by the recipe
+# cards, whereas the API is happier with larger pages.
+Rails.application.config.x.recipes_per_page = Integer(ENV.fetch("RECIPES_PER_PAGE", 12))

--- a/spec/requests/recipes_pagination_spec.rb
+++ b/spec/requests/recipes_pagination_spec.rb
@@ -1,0 +1,105 @@
+require "rails_helper"
+
+RSpec.describe "Recipes pagination" do
+  let(:per_page) { Rails.application.config.x.recipes_per_page }
+
+  # Ordered newest first (created_at desc, id desc), so "Paginated Recipe 15"
+  # heads page one and "Paginated Recipe 01" tails the last page.
+  let!(:recipes) do
+    (1..15).map { |n| create(:recipe, title: format("Paginated Recipe %02d", n)) }
+  end
+
+  let(:first_page_titles) { recipes.last(per_page).map(&:title) }
+  let(:second_page_titles) { recipes.first(15 - per_page).map(&:title) }
+
+  it "defaults to 12 recipes per page" do
+    expect(per_page).to eq(12)
+  end
+
+  describe "GET /recipes" do
+    it "shows only the first page of recipes" do
+      get recipes_path
+
+      expect(response).to have_http_status(:ok)
+      first_page_titles.each { |title| expect(response.body).to include(title) }
+      second_page_titles.each { |title| expect(response.body).not_to include(title) }
+    end
+
+    it "renders a link to the next page" do
+      get recipes_path
+
+      expect(response.body).to include("Next")
+      expect(response.body).to include("/recipes?page=2")
+    end
+
+    it "shows the remaining recipes on page 2" do
+      get recipes_path, params: { page: 2 }
+
+      expect(response).to have_http_status(:ok)
+      second_page_titles.each { |title| expect(response.body).to include(title) }
+      first_page_titles.each { |title| expect(response.body).not_to include(title) }
+    end
+
+    it "falls back to the last page when the page is out of range" do
+      get recipes_path, params: { page: 99 }
+
+      expect(response).to have_http_status(:ok)
+      second_page_titles.each { |title| expect(response.body).to include(title) }
+    end
+
+    it "does not render the nav when everything fits on one page" do
+      Recipe.destroy_all
+      create(:recipe, title: "Only Recipe")
+
+      get recipes_path
+
+      expect(response.body).to include("Only Recipe")
+      expect(response.body).not_to include('aria-label="Pagination"')
+    end
+  end
+
+  describe "GET /recipes/search" do
+    it "paginates matching recipes" do
+      get search_recipes_path, params: { query: "Paginated Recipe" }
+
+      expect(response).to have_http_status(:ok)
+      first_page_titles.each { |title| expect(response.body).to include(title) }
+      second_page_titles.each { |title| expect(response.body).not_to include(title) }
+    end
+
+    it "keeps the query when paging" do
+      get search_recipes_path, params: { query: "Paginated Recipe", page: 2 }
+
+      expect(response).to have_http_status(:ok)
+      second_page_titles.each { |title| expect(response.body).to include(title) }
+      expect(response.body).to include("query=Paginated+Recipe")
+    end
+
+    it "falls back to the last page when the page is out of range" do
+      get search_recipes_path, params: { query: "Paginated Recipe", page: 99 }
+
+      expect(response).to have_http_status(:ok)
+      second_page_titles.each { |title| expect(response.body).to include(title) }
+    end
+
+    it "renders the empty state for a blank query without a pagination nav" do
+      get search_recipes_path, params: { query: "" }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).not_to include('aria-label="Pagination"')
+    end
+  end
+
+  describe "saving a recipe from a paginated list" do
+    let(:user) { create(:user) }
+
+    before { sign_in(user) }
+
+    it "returns the user to the page they were on" do
+      post toggle_meal_path, params: { recipe_id: recipes.first.id },
+                             headers: { "HTTP_REFERER" => "#{recipes_url}?page=2" }
+
+      expect(response).to redirect_to("#{recipes_url}?page=2")
+    end
+  end
+end

--- a/spec/system/recipes_pagination_spec.rb
+++ b/spec/system/recipes_pagination_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe "Recipes pagination", type: :system do
+  it "pages through the recipe list" do
+    recipes = (1..15).map { |n| create(:recipe, title: format("Paginated Recipe %02d", n)) }
+    newest = recipes.last.title
+    oldest = recipes.first.title
+
+    visit recipes_path
+
+    expect(page).to have_content(newest)
+    expect(page).to have_no_content(oldest)
+
+    click_link "Next →"
+
+    expect(page).to have_content(oldest)
+    expect(page).to have_no_content(newest)
+    expect(page).to have_current_path(recipes_path(page: 2))
+  end
+end


### PR DESCRIPTION
# :sparkles: Paginate the HTML recipes list and search

Closes #63

Adds pagination to the HTML recipes list and search results.

## Decision: pagy, not Kaminari

The issue suggested Kaminari, but `pagy` (~> 9.0) is already a dependency and already powers the JSON API, so this uses pagy. No new gems, and the `Gemfile` is untouched.

## What's in here

- `RecipesController` includes `Pagy::Backend` **directly** (not in `ApplicationController`) — only the recipe list and search need it.
- `#index` now paginates instead of `Recipe.all`.
- `#search` wraps its existing relation in `pagy`. The WHERE clause is untouched; the blank-query branch still returns `[]` (and sets `@pagy = nil`) so the empty state keeps working — an Array has no Pagy.
- Shared `paginate_recipes` helper adds `includes(:category)` (kills the N+1 on the recipe cards) and a deterministic `order(created_at: :desc, id: :desc)` so page boundaries are stable.
- **12 per page**, a clean multiple of the 1/2/3-column Tailwind grid. Configurable in `config/initializers/pagy.rb` via `Rails.application.config.x.recipes_per_page` (overridable with `RECIPES_PER_PAGE`). Deliberately kept separate from `Pagy::DEFAULT` so the JSON API's page size is unchanged.
- New reusable `app/views/shared/_pagination.html.erb`: Tailwind nav styled to match the existing app (blue-600 current page, gray links, `border-t` divider), with a mobile "Page X of Y" fallback. Renders nothing when there's only one page or when `pagy` is nil. Rendered on both index and search.
- Links are built from `request.query_parameters.merge("page" => n)`, so **existing query params are preserved** — paging through `/recipes/search?query=eggs` keeps `query=eggs`.
- Also closes a pre-existing unclosed `<div>` in `recipes/index.html.erb` while adding the nav.

## Pagination state in basket actions

`MealsController#toggle` (what the "Plan" button on a recipe card hits) already uses `redirect_back fallback_location: recipes_path`, so saving a recipe from page 3 returns you to page 3 rather than page 1. No controller change was needed — added a request spec to lock the behaviour in.

## Tests

- `spec/requests/recipes_pagination_spec.rb` — index and search across page 1, page 2, an out-of-range page (the `overflow` extra is configured `:last_page`, so page 99 renders the last page with a 200 rather than raising), query preservation, blank-query search, single-page (no nav), and the basket round-trip.
- `spec/system/recipes_pagination_spec.rb` — clicks "Next →" through to page 2. Not flaky in repeated runs.

Suite: **403 examples, 0 failures**. RuboCop: **134 files, no offenses**.

## Deferred / left out

- **Infinite scroll** (the issue's bonus checkbox) — deliberately skipped. Classic pagination first; infinite scroll can be layered on later with pagy's `countless` extra + a Turbo Frame if it's still wanted.
- **`Pagy::DEFAULT[:items]` in the initializer** — left as-is. It's a no-op on pagy 9 (the key was renamed to `:limit`, and the core default is also 20, so behaviour is identical), but fixing it touches the JSON API's page size and belongs in its own change.

## Heads-up for reviewers

Expect a small conflict in `RecipesController#search` with the full-text search work on #65. This PR deliberately leaves the query-building lines byte-identical and only appends one line (`@pagy, @recipes = paginate_recipes(@recipes)`) after the `if/else`, so the conflict should resolve by keeping the new WHERE clause and re-applying that one line.
